### PR TITLE
allowing async functions to be called like synced functions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,10 +31,10 @@ install_requires =
 package_dir =
     =src
 packages = aerovaldb
-tests_require = 
+tests_require =
     tox:tox
     pytest
-    
+
 
 [options.entry_points]
 aerovaldb =

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -1,7 +1,7 @@
 import abc
 import functools
 import inspect
-import aiofile
+from .utils import async_and_sync
 
 
 def get_method(route):
@@ -106,6 +106,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/glob_stats/{project}/{experiment}/{frequency}")
     async def get_glob_stats(
         self, project: str, experiment: str, frequency: str, /, *args, **kwargs
@@ -135,6 +136,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/contour/{project}/{experiment}/{obsvar}/{model}")
     async def get_contour(
         self, project: str, experiment: str, obsvar: str, model: str, /, *args, **kwargs
@@ -170,6 +172,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/ts/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}")
     async def get_ts(
         self,
@@ -228,6 +231,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method(
         "/v0/ts_weekly/{project}/{experiment}/{station}_{network}-{obsvar}_{layer}"
     )
@@ -282,6 +286,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/experiments/{project}")
     async def get_experiments(self, project: str, /, *args, **kwargs):
         """Fetches a list of experiments for a project from the db.
@@ -299,6 +304,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/config/{project}/{experiment}")
     async def get_config(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches a configuration from the db.
@@ -319,6 +325,7 @@ class AerovalDB(abc.ABC):
 
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/menu/{project}/{experiment}")
     async def get_menu(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches a menu configuartion from the db.
@@ -338,6 +345,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/statistics/{project}/{experiment}")
     async def get_statistics(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches statistics for an experiment.
@@ -357,6 +365,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/ranges/{project}/{experiment}")
     async def get_ranges(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches ranges from the db.
@@ -376,6 +385,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/regions/{project}/{experiment}")
     async def get_regions(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches regions from db.
@@ -395,6 +405,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/model_style/{project}")
     async def get_models_style(self, project: str, /, *args, **kwargs):
         """Fetches model styles from db.
@@ -414,6 +425,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method(
         "/v0/map/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}"
     )
@@ -474,6 +486,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method(
         "/v0/scat/{project}/{experiment}/{network}-{obsvar}_{layer}_{model}-{modvar}"
     )
@@ -534,6 +547,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/profiles/{project}/{experiment}/{station}/{network}/{obsvar}")
     async def get_profiles(
         self,
@@ -578,6 +592,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/hm_ts/{project}/{experiment}")
     async def get_hm_ts(
         self,
@@ -620,6 +635,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method(
         "/v0/forecast/{project}/{experiment}/{station}/{network}/{obsvar}/{layer}"
     )
@@ -674,6 +690,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/gridded_map/{project}/{experiment}/{obsvar}/{model}")
     async def get_gridded_map(
         self, project: str, experiment: str, obsvar: str, model: str, /, *args, **kwargs
@@ -709,6 +726,7 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
     @get_method("/v0/report/{project}/{experiment}/{title}")
     async def get_report(
         self, project: str, experiment: str, title: str, /, *args, **kwargs

--- a/src/aerovaldb/utils.py
+++ b/src/aerovaldb/utils.py
@@ -23,6 +23,7 @@ def async_and_sync(function: Callable) -> Callable:
     :args function: function/property to wrap
     :return: modified function
     """
+
     @functools.wraps(function)
     def async_and_sync_wrap(*args, **kwargs):
         if _has_async_loop():
@@ -31,7 +32,3 @@ def async_and_sync(function: Callable) -> Callable:
             return asyncio.run(function(*args, **kwargs))
 
     return async_and_sync_wrap
-
-
-
-

--- a/src/aerovaldb/utils.py
+++ b/src/aerovaldb/utils.py
@@ -1,0 +1,37 @@
+import asyncio
+import functools
+from typing import Callable
+
+
+def _has_async_loop():
+    is_async = False
+    try:
+        loop = asyncio.get_running_loop()
+        if loop is not None:
+            is_async = True
+    except RuntimeError:
+        is_async = False
+    return is_async
+
+
+def async_and_sync(function: Callable) -> Callable:
+    """Wrap an async method to a sync method.
+
+    This allows to run the async method in both async and sync contexts transparently
+    without any additional code.
+
+    :args function: function/property to wrap
+    :return: modified function
+    """
+    @functools.wraps(function)
+    def async_and_sync_wrap(*args, **kwargs):
+        if _has_async_loop():
+            return function(*args, **kwargs)
+        else:
+            return asyncio.run(function(*args, **kwargs))
+
+    return async_and_sync_wrap
+
+
+
+

--- a/tests/test_jsonfiledb.py
+++ b/tests/test_jsonfiledb.py
@@ -278,7 +278,6 @@ def test_getter_sync(resource: str, fun: str, args: list, kwargs: dict, expected
         assert data["path"] == expected
 
 
-
 @pytest.mark.asyncio
 async def test_put_glob_stats():
     # TODO: These tests should ideally cleanup after themselves. For now

--- a/tests/test_jsonfiledb.py
+++ b/tests/test_jsonfiledb.py
@@ -4,10 +4,7 @@ import asyncio
 
 pytest_plugins = ("pytest_asyncio",)
 
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("resource", (("json_files:./tests/test-db/json",)))
-@pytest.mark.parametrize(
+get_parameters = [
     "fun,args,kwargs,expected",
     (
         (
@@ -129,7 +126,12 @@ pytest_plugins = ("pytest_asyncio",)
             "./reports/project/experiment/",
         ),
     ),
-)
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource", (("json_files:./tests/test-db/json",)))
+@pytest.mark.parametrize(*get_parameters)
 async def test_getter(resource: str, fun: str, args: list, kwargs: dict, expected):
     with aerovaldb.open(resource) as db:
         f = getattr(db, fun)
@@ -143,129 +145,7 @@ async def test_getter(resource: str, fun: str, args: list, kwargs: dict, expecte
 
 
 @pytest.mark.parametrize("resource", (("json_files:./tests/test-db/json",)))
-@pytest.mark.parametrize(
-    "fun,args,kwargs,expected",
-    (
-        (
-            "get_glob_stats",
-            ["project", "experiment", "frequency"],
-            None,
-            "./project/experiment/hm/",
-        ),
-        (
-            "get_contour",
-            ["project", "experiment", "modvar", "model"],
-            None,
-            "./project/experiment/contour/",
-        ),
-        (
-            "get_ts",
-            ["project", "experiment", "region", "network", "obsvar", "layer"],
-            None,
-            "./project/experiment/ts/",
-        ),
-        (
-            "get_ts_weekly",
-            ["project", "experiment", "region", "network", "obsvar", "layer"],
-            None,
-            "./project/experiment/ts/dirunal/",
-        ),
-        ("get_experiments", ["project"], None, "./project/"),
-        ("get_config", ["project", "experiment"], None, "./project/experiment/"),
-        ("get_menu", ["project", "experiment"], None, "./project/experiment/"),
-        ("get_statistics", ["project", "experiment"], None, "./project/experiment/"),
-        ("get_ranges", ["project", "experiment"], None, "./project/experiment/"),
-        ("get_regions", ["project", "experiment"], None, "./project/experiment/"),
-        ("get_models_style", ["project"], None, "./project/"),
-        (
-            "get_models_style",
-            ["project"],
-            {"experiment": "experiment"},
-            "./project/experiment/",
-        ),
-        (
-            "get_map",
-            ["project", "experiment", "network", "obsvar", "layer", "model", "modvar"],
-            None,
-            "./project/experiment/map/",
-        ),
-        (
-            "get_map",
-            ["project", "experiment", "network", "obsvar", "layer", "model", "modvar"],
-            {"time": "time"},
-            "./project/experiment/map/with_time",
-        ),
-        (
-            "get_ts_weekly",
-            ["project", "experiment", "region", "network", "obsvar", "layer"],
-            None,
-            "./project/experiment/ts/dirunal/",
-        ),
-        (
-            "get_scat",
-            ["project", "experiment", "network", "obsvar", "layer", "model", "modvar"],
-            None,
-            "./project/experiment/scat/",
-        ),
-        (
-            "get_scat",
-            ["project", "experiment", "network", "obsvar", "layer", "model", "modvar"],
-            {"time": "time"},
-            "./project/experiment/scat/time",
-        ),
-        (
-            "get_profiles",
-            ["project", "experiment", "region", "network", "obsvar"],
-            None,
-            "./project/experiment/profiles/",
-        ),
-        (
-            "get_hm_ts",
-            ["project", "experiment"],
-            None,
-            "project/experiment/hm/ts/stats_ts.json",
-        ),
-        (
-            "get_hm_ts",
-            ["project", "experiment"],
-            {
-                "network": "network",
-                "obsvar": "obsvar",
-                "layer": "layer",
-            },
-            "./project/experiment/hm/ts/network-obsvar-layer",
-        ),
-        (
-            "get_hm_ts",
-            ["project", "experiment"],
-            {
-                "network": "network",
-                "obsvar": "obsvar",
-                "layer": "layer",
-                "station": "region",
-            },
-            "./project/experiment/hm/ts/",
-        ),
-        (
-            "get_forecast",
-            ["project", "experiment", "region", "network", "obsvar", "layer"],
-            None,
-            "./project/experiment/forecast/",
-        ),
-        (
-            "get_gridded_map",
-            ["project", "experiment", "obsvar", "model"],
-            None,
-            "./project/experiment/contour/",
-        ),
-        (
-            "get_report",
-            ["project", "experiment", "title"],
-            None,
-            "./reports/project/experiment/",
-        ),
-    ),
-)
+@pytest.mark.parametrize(*get_parameters)
 def test_getter_sync(resource: str, fun: str, args: list, kwargs: dict, expected):
     with aerovaldb.open(resource) as db:
         f = getattr(db, fun)

--- a/tests/test_jsonfiledb.py
+++ b/tests/test_jsonfiledb.py
@@ -142,6 +142,143 @@ async def test_getter(resource: str, fun: str, args: list, kwargs: dict, expecte
         assert data["path"] == expected
 
 
+@pytest.mark.parametrize("resource", (("json_files:./tests/test-db/json",)))
+@pytest.mark.parametrize(
+    "fun,args,kwargs,expected",
+    (
+        (
+            "get_glob_stats",
+            ["project", "experiment", "frequency"],
+            None,
+            "./project/experiment/hm/",
+        ),
+        (
+            "get_contour",
+            ["project", "experiment", "modvar", "model"],
+            None,
+            "./project/experiment/contour/",
+        ),
+        (
+            "get_ts",
+            ["project", "experiment", "region", "network", "obsvar", "layer"],
+            None,
+            "./project/experiment/ts/",
+        ),
+        (
+            "get_ts_weekly",
+            ["project", "experiment", "region", "network", "obsvar", "layer"],
+            None,
+            "./project/experiment/ts/dirunal/",
+        ),
+        ("get_experiments", ["project"], None, "./project/"),
+        ("get_config", ["project", "experiment"], None, "./project/experiment/"),
+        ("get_menu", ["project", "experiment"], None, "./project/experiment/"),
+        ("get_statistics", ["project", "experiment"], None, "./project/experiment/"),
+        ("get_ranges", ["project", "experiment"], None, "./project/experiment/"),
+        ("get_regions", ["project", "experiment"], None, "./project/experiment/"),
+        ("get_models_style", ["project"], None, "./project/"),
+        (
+            "get_models_style",
+            ["project"],
+            {"experiment": "experiment"},
+            "./project/experiment/",
+        ),
+        (
+            "get_map",
+            ["project", "experiment", "network", "obsvar", "layer", "model", "modvar"],
+            None,
+            "./project/experiment/map/",
+        ),
+        (
+            "get_map",
+            ["project", "experiment", "network", "obsvar", "layer", "model", "modvar"],
+            {"time": "time"},
+            "./project/experiment/map/with_time",
+        ),
+        (
+            "get_ts_weekly",
+            ["project", "experiment", "region", "network", "obsvar", "layer"],
+            None,
+            "./project/experiment/ts/dirunal/",
+        ),
+        (
+            "get_scat",
+            ["project", "experiment", "network", "obsvar", "layer", "model", "modvar"],
+            None,
+            "./project/experiment/scat/",
+        ),
+        (
+            "get_scat",
+            ["project", "experiment", "network", "obsvar", "layer", "model", "modvar"],
+            {"time": "time"},
+            "./project/experiment/scat/time",
+        ),
+        (
+            "get_profiles",
+            ["project", "experiment", "region", "network", "obsvar"],
+            None,
+            "./project/experiment/profiles/",
+        ),
+        (
+            "get_hm_ts",
+            ["project", "experiment"],
+            None,
+            "project/experiment/hm/ts/stats_ts.json",
+        ),
+        (
+            "get_hm_ts",
+            ["project", "experiment"],
+            {
+                "network": "network",
+                "obsvar": "obsvar",
+                "layer": "layer",
+            },
+            "./project/experiment/hm/ts/network-obsvar-layer",
+        ),
+        (
+            "get_hm_ts",
+            ["project", "experiment"],
+            {
+                "network": "network",
+                "obsvar": "obsvar",
+                "layer": "layer",
+                "station": "region",
+            },
+            "./project/experiment/hm/ts/",
+        ),
+        (
+            "get_forecast",
+            ["project", "experiment", "region", "network", "obsvar", "layer"],
+            None,
+            "./project/experiment/forecast/",
+        ),
+        (
+            "get_gridded_map",
+            ["project", "experiment", "obsvar", "model"],
+            None,
+            "./project/experiment/contour/",
+        ),
+        (
+            "get_report",
+            ["project", "experiment", "title"],
+            None,
+            "./reports/project/experiment/",
+        ),
+    ),
+)
+def test_getter_sync(resource: str, fun: str, args: list, kwargs: dict, expected):
+    with aerovaldb.open(resource) as db:
+        f = getattr(db, fun)
+
+        if kwargs is not None:
+            data = f(*args, **kwargs)
+        else:
+            data = f(*args)
+
+        assert data["path"] == expected
+
+
+
 @pytest.mark.asyncio
 async def test_put_glob_stats():
     # TODO: These tests should ideally cleanup after themselves. For now


### PR DESCRIPTION
This PR allows the getter tasks to be run as methods rather than co-routines if no co-routine-loops exist.

Tests included for both co-routine and method approach.