### PR TITLE
Better exceptions and types

### DIFF
--- a/src/aerovaldb/__init__.py
+++ b/src/aerovaldb/__init__.py
@@ -3,3 +3,5 @@ from importlib import metadata
 __version__ = metadata.version(__package__)
 
 from .plugins import list_engines, open
+from .types import *
+from .exceptions import *

--- a/src/aerovaldb/exceptions.py
+++ b/src/aerovaldb/exceptions.py
@@ -1,0 +1,6 @@
+class FileDoesNotExist(IOError):
+    """
+    Exception raised by jsondb in FILE_PATH mode, if the resulting file
+    does not exist.
+    """
+    

--- a/src/aerovaldb/jsonfiledb.py
+++ b/src/aerovaldb/jsonfiledb.py
@@ -7,7 +7,8 @@ import json
 import orjson
 import aiofile
 from enum import Enum
-AccessType = Enum("AccessType", ["JSON_STR", "FILE_PATH", "OBJ"])
+from .exceptions import FileDoesNotExist
+from .types import AccessType
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +117,8 @@ class AerovalJsonFileDB(AerovalDB):
         )
 
         if access_type == AccessType.FILE_PATH:
-            logger.debug(file_path)
+            if not os.path.exists(file_path):
+                raise FileDoesNotExist(f"File {file_path} does not exist.")
             return file_path
 
         if access_type == AccessType.JSON_STR:

--- a/src/aerovaldb/types.py
+++ b/src/aerovaldb/types.py
@@ -1,0 +1,4 @@
+from enum import Enum
+
+
+AccessType = Enum("AccessType", ["JSON_STR", "FILE_PATH", "OBJ"])

--- a/tests/test_jsonfiledb.py
+++ b/tests/test_jsonfiledb.py
@@ -128,7 +128,6 @@ get_parameters = [
     ),
 ]
 
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("resource", (("json_files:./tests/test-db/json",)))
 @pytest.mark.parametrize(*get_parameters)
@@ -191,3 +190,10 @@ async def test_put_timeseries():
         )
 
         assert obj["data"] == read_data["data"]
+
+
+@pytest.mark.asyncio
+async def test_file_does_not_exist():
+    with aerovaldb.open("json_files:./tests/test-db/json") as db:
+        with pytest.raises(aerovaldb.FileDoesNotExist):
+            await db.get_experiments("non-existent-project", access_type = aerovaldb.AccessType.FILE_PATH)


### PR DESCRIPTION
Places aerovaldb wide exceptions and types in `aerovaldb.exceptions` and `aerovaldb.types` respectively for easy importing.