### PR TITLE
Small fix to `get_experiments()`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.3.dev0
+version = 0.0.3
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.3
+version = 0.0.4.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -365,12 +365,16 @@ class AerovalJsonFileDB(AerovalDB):
         # If an experiments.json file exists, read it.
         try:
             access_type = self._normalize_access_type(kwargs.pop("access_type", None))
-            experiments = await self._get("/v0/experiments/{project}", {"project": project}, access_type=access_type)
+            experiments = await self._get(
+                "/v0/experiments/{project}",
+                {"project": project},
+                access_type=access_type,
+            )
         except (FileDoesNotExist, FileNotFoundError):
             pass
         else:
             return experiments
-        
+
         # Otherwise generate it based on config and expinfo.public information.
         experiments = {}
         for exp in self._list_experiments(project, has_results=True):

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -362,6 +362,16 @@ class AerovalJsonFileDB(AerovalDB):
 
     @async_and_sync
     async def get_experiments(self, project: str, /, *args, exp_order=None, **kwargs):
+        # If an experiments.json file exists, read it.
+        try:
+            access_type = self._normalize_access_type(kwargs.pop("access_type", None))
+            experiments = await self._get("/v0/experiments/{project}", {"project": project}, access_type=access_type)
+        except (FileDoesNotExist, FileNotFoundError):
+            pass
+        else:
+            return experiments
+        
+        # Otherwise generate it based on config and expinfo.public information.
         experiments = {}
         for exp in self._list_experiments(project, has_results=True):
             public = False

--- a/tests/jsondb/test_jsonfiledb.py
+++ b/tests/jsondb/test_jsonfiledb.py
@@ -54,6 +54,7 @@ get_parameters = [
         ("get_ranges", ["project", "experiment"], None, "./project/experiment/"),
         ("get_regions", ["project", "experiment"], None, "./project/experiment/"),
         ("get_models_style", ["project"], None, "./project/"),
+        ("get_experiments", ["project"], None, "./project/"),
         (
             "get_models_style",
             ["project"],
@@ -393,11 +394,10 @@ def test_list_experiments_results_only():
 
 def test_get_experiments():
     with aerovaldb.open("json_files:./tests/test-db/json") as db:
-        experiments = db.get_experiments("project")
+        experiments = db.get_experiments("project-no-experiments-json")
 
         assert experiments == {
             "experiment": {"public": True},
-            "experiment-old": {"public": False},
         }
 
 

--- a/tests/test-db/json/project-no-experiments-json/experiment/cfg_project-no-experiments-json_experiment.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/cfg_project-no-experiments-json_experiment.json
@@ -1,0 +1,7 @@
+{
+    "path": "./project/experiment/",
+    "exp_info": {
+        "pyaerocom_version": "0.13.5",
+        "public": true
+    }
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/contour/modvar_model.geojson
+++ b/tests/test-db/json/project-no-experiments-json/experiment/contour/modvar_model.geojson
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/contour/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/contour/obsvar_model.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/contour/obsvar_model.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/contour/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/forecast/region_network-obsvar_layer.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/forecast/region_network-obsvar_layer.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/forecast/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/hm/glob_stats_frequency.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/hm/glob_stats_frequency.json
@@ -1,0 +1,10 @@
+{
+    "path": "./project/experiment/hm/",
+    "variable": {
+        "network": {
+            "layer": {
+                "path": "./project/experiment/hm/regional_stats"
+            }
+        }
+    }
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/hm/ts/_network-obsvar-layer.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/hm/ts/_network-obsvar-layer.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/hm/ts/network-obsvar-layer"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/hm/ts/region-network-obsvar-layer.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/hm/ts/region-network-obsvar-layer.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/hm/ts/region-network-obsvar-layer"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/map/network-obsvar_layer_model-modvar_time.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/map/network-obsvar_layer_model-modvar_time.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/map/with_time"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/menu.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/menu.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/models-style.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/models-style.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/profiles/region_network-obsvar.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/profiles/region_network-obsvar.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/profiles/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/ranges.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/ranges.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/regions.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/regions.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/scat/network-obsvar_layer_model-modvar_time.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/scat/network-obsvar_layer_model-modvar_time.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/scat/time"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/statistics.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/statistics.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/ts/diurnal/location_network-obsvar_layer.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/ts/diurnal/location_network-obsvar_layer.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/ts/dirunal/"
+}

--- a/tests/test-db/json/project-no-experiments-json/experiment/ts/location_network-obsvar_layer.json
+++ b/tests/test-db/json/project-no-experiments-json/experiment/ts/location_network-obsvar_layer.json
@@ -1,0 +1,3 @@
+{
+    "path": "./project/experiment/ts/"
+}


### PR DESCRIPTION
Small fix to `get_experiments()` that ensures backwards compatibility. `experiments.json` will be read if it exists, but if not it will be generated on the fly.