### PR TITLE
A number of fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ with aerovaldb.open('json_files:path/to/data/') as db:
     try:
         fh = db.get_map(*args, access_type=aerovaldb.AccessType.FILE_PATH)
         # ... sendfile of filehandle
-    except aerovaldb.FileDoesNotExist as e:
+    except FileNotFoundError as e:
         json = db.get_map(*args, access_type=aerovaldb.AccessType.JSON_STR)
         # ... send json string to client
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.4.dev0
+version = 0.0.4
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.4
+version = 0.0.5.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -875,7 +875,12 @@ class AerovalDB(abc.ABC):
 
     @async_and_sync
     async def get_by_uuid(
-        self, uuid: str, /, access_type: str | AccessType, cache: bool = False
+        self,
+        uuid: str,
+        /,
+        access_type: str | AccessType,
+        cache: bool = False,
+        default=None,
     ):
         """Gets a stored object by its UUID.
 

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -578,6 +578,16 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    def list_map(self, project: str, experiment: str) -> Generator[str, None, None]:
+        """Lists all map files for a given project / experiment combination.
+
+        :param project: The project ID.
+        :param experiment: The experiment ID.
+
+        :return Generator with the UUIDs.
+        """
+        raise NotImplementedError
+
     @async_and_sync
     @get_method(ROUTE_SCATTER)
     async def get_scatter(

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -4,6 +4,7 @@ import inspect
 from typing import Generator
 from .types import AccessType
 from .utils import async_and_sync
+from .routes import *
 
 
 def get_method(route):
@@ -109,7 +110,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/glob_stats/{project}/{experiment}/{frequency}")
+    @get_method(ROUTE_GLOB_STATS)
     async def get_glob_stats(
         self, project: str, experiment: str, frequency: str, /, *args, **kwargs
     ):
@@ -126,7 +127,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/regional_stats/{project}/{experiment}/{frequency}")
+    @get_method(ROUTE_REG_STATS)
     async def get_regional_stats(
         self,
         project: str,
@@ -150,7 +151,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/heatmap/{project}/{experiment}/{frequency}")
+    @get_method(ROUTE_HEATMAP)
     async def get_heatmap(
         self,
         project: str,
@@ -173,7 +174,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/glob_stats/{project}/{experiment}/{frequency}")
+    @put_method(ROUTE_GLOB_STATS)
     async def put_glob_stats(
         self, obj, project: str, experiment: str, frequency: str, /, *args, **kwargs
     ):
@@ -186,8 +187,20 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    def list_glob_stats(
+        self, project: str, experiment: str
+    ) -> Generator[str, None, None]:
+        """Generator that lists the uuid for each glob_stats object.
+
+        :param project: str
+        :param experiment: str
+
+        :return Generator of UUIDs.
+        """
+        raise NotImplementedError
+
     @async_and_sync
-    @get_method("/v0/contour/{project}/{experiment}/{obsvar}/{model}")
+    @get_method(ROUTE_CONTOUR)
     async def get_contour(
         self, project: str, experiment: str, obsvar: str, model: str, /, *args, **kwargs
     ):
@@ -205,7 +218,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/contour/{project}/{experiment}/{obsvar}/{model}")
+    @put_method(ROUTE_CONTOUR)
     async def put_contour(
         self,
         obj,
@@ -228,7 +241,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/ts/{project}/{experiment}/{location}/{network}/{obsvar}/{layer}")
+    @get_method(ROUTE_TIMESERIES)
     async def get_timeseries(
         self,
         project: str,
@@ -257,7 +270,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/ts/{project}/{experiment}/{location}/{network}/{obsvar}/{layer}")
+    @put_method(ROUTE_TIMESERIES)
     async def put_timeseries(
         self,
         obj,
@@ -299,9 +312,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method(
-        "/v0/ts_weekly/{project}/{experiment}/{location}_{network}-{obsvar}_{layer}"
-    )
+    @get_method(ROUTE_TIMESERIES_WEEKLY)
     async def get_timeseries_weekly(
         self,
         project: str,
@@ -326,9 +337,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method(
-        "/v0/ts_weekly/{project}/{experiment}/{location}_{network}-{obsvar}_{layer}"
-    )
+    @put_method(ROUTE_TIMESERIES_WEEKLY)
     async def put_timeseries_weekly(
         self,
         obj,
@@ -355,7 +364,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/experiments/{project}")
+    @get_method(ROUTE_EXPERIMENTS)
     async def get_experiments(self, project: str, /, *args, **kwargs):
         """Fetches a list of experiments for a project from the db.
 
@@ -377,7 +386,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/config/{project}/{experiment}")
+    @get_method(ROUTE_CONFIG)
     async def get_config(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches a configuration from the db.
 
@@ -387,7 +396,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/config/{project}/{experiment}")
+    @put_method(ROUTE_CONFIG)
     async def put_config(self, obj, project: str, experiment: str, /, *args, **kwargs):
         """Stores a configuration to the db.
 
@@ -399,7 +408,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/menu/{project}/{experiment}")
+    @get_method(ROUTE_MENU)
     async def get_menu(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches a menu configuartion from the db.
 
@@ -409,7 +418,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/menu/{project}/{experiment}")
+    @put_method(ROUTE_MENU)
     async def put_menu(self, obj, project: str, experiment: str, /, *args, **kwargs):
         """Stores a menu configuration in the db.
 
@@ -420,7 +429,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/statistics/{project}/{experiment}")
+    @get_method(ROUTE_STATISTICS)
     async def get_statistics(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches statistics for an experiment.
 
@@ -430,7 +439,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/statistics/{project}/{experiment}")
+    @put_method(ROUTE_STATISTICS)
     async def put_statistics(
         self, obj, project: str, experiment: str, /, *args, **kwargs
     ):
@@ -443,7 +452,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/ranges/{project}/{experiment}")
+    @get_method(ROUTE_RANGES)
     async def get_ranges(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches ranges from the db.
 
@@ -453,7 +462,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/ranges/{project}/{experiment}")
+    @put_method(ROUTE_RANGES)
     async def put_ranges(self, obj, project: str, experiment: str, /, *args, **kwargs):
         """Stores ranges in db.
 
@@ -464,7 +473,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/regions/{project}/{experiment}")
+    @get_method(ROUTE_REGIONS)
     async def get_regions(self, project: str, experiment: str, /, *args, **kwargs):
         """Fetches regions from db.
 
@@ -474,7 +483,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/regions/{project}/{experiment}")
+    @put_method(ROUTE_REGIONS)
     async def put_regions(self, obj, project: str, experiment: str, /, *args, **kwargs):
         """Stores regions in db.
 
@@ -485,7 +494,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/model_style/{project}")
+    @get_method(ROUTE_MODELS_STYLE)
     async def get_models_style(
         self, project: str, /, experiment: str | None = None, *args, **kwargs
     ):
@@ -497,7 +506,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/model_style/{project}")
+    @put_method(ROUTE_MODELS_STYLE)
     async def put_models_style(
         self, obj, project: str, /, experiment: str | None = None, *args, **kwargs
     ):
@@ -510,9 +519,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method(
-        "/v0/map/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}"
-    )
+    @get_method(ROUTE_MAP)
     async def get_map(
         self,
         project: str,
@@ -541,9 +548,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method(
-        "/v0/map/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}"
-    )
+    @put_method(ROUTE_MAP)
     async def put_map(
         self,
         obj,
@@ -574,9 +579,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method(
-        "/v0/scat/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}/{time}"
-    )
+    @get_method(ROUTE_SCATTER)
     async def get_scatter(
         self,
         project: str,
@@ -605,9 +608,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method(
-        "/v0/scat/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}/{time}"
-    )
+    @put_method(ROUTE_SCATTER)
     async def put_scatter(
         self,
         obj,
@@ -638,7 +639,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/profiles/{project}/{experiment}/{location}/{network}/{obsvar}")
+    @get_method(ROUTE_PROFILES)
     async def get_profiles(
         self,
         project: str,
@@ -661,7 +662,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/profiles/{project}/{experiment}/{location}/{network}/{obsvar}")
+    @put_method(ROUTE_PROFILES)
     async def put_profiles(
         self,
         obj,
@@ -686,7 +687,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/hm_ts/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}")
+    @get_method(ROUTE_HEATMAP_TIMESERIES)
     async def get_heatmap_timeseries(
         self,
         project: str,
@@ -711,7 +712,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/hm_ts/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}")
+    @put_method(ROUTE_HEATMAP_TIMESERIES)
     async def put_heatmap_timeseries(
         self,
         obj,
@@ -738,9 +739,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method(
-        "/v0/forecast/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}"
-    )
+    @get_method(ROUTE_FORECAST)
     async def get_forecast(
         self,
         project: str,
@@ -765,9 +764,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method(
-        "/v0/forecast/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}"
-    )
+    @put_method(ROUTE_FORECAST)
     async def put_forecast(
         self,
         obj,
@@ -794,7 +791,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/gridded_map/{project}/{experiment}/{obsvar}/{model}")
+    @get_method(ROUTE_GRIDDED_MAP)
     async def get_gridded_map(
         self, project: str, experiment: str, obsvar: str, model: str, /, *args, **kwargs
     ):
@@ -808,7 +805,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/gridded_map/{project}/{experiment}/{obsvar}/{model}")
+    @put_method(ROUTE_GRIDDED_MAP)
     async def put_gridded_map(
         self,
         obj,
@@ -831,7 +828,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @get_method("/v0/report/{project}/{experiment}/{title}")
+    @get_method(ROUTE_REPORT)
     async def get_report(
         self, project: str, experiment: str, title: str, /, *args, **kwargs
     ):
@@ -844,7 +841,7 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    @put_method("/v0/report/{project}/{experiment}/{title}")
+    @put_method(ROUTE_REPORT)
     async def put_report(
         self, obj, project: str, experiment: str, title: str, /, *args, **kwargs
     ):

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -372,6 +372,15 @@ class AerovalDB(abc.ABC):
         """
         raise NotImplementedError
 
+    @async_and_sync
+    @put_method(ROUTE_EXPERIMENTS)
+    async def put_experiments(self, obj, project: str, /, *args, **kwargs):
+        """Stores a list of experiments for a project from the db.
+
+        :param project: Project ID.
+        """
+        raise NotImplementedError
+
     def rm_experiment_data(self, project: str, experiment: str):
         """Deletes ALL data associated with an experiment.
 

--- a/src/aerovaldb/exceptions.py
+++ b/src/aerovaldb/exceptions.py
@@ -1,10 +1,3 @@
-class FileDoesNotExist(IOError):
-    """
-    Exception raised by jsondb in FILE_PATH mode, if the resulting file
-    does not exist.
-    """
-
-
 class UnusedArguments(ValueError):
     """
     Raised by jsondb if args or kwargs remain after matching (which

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -384,7 +384,7 @@ class AerovalJsonFileDB(AerovalDB):
                 config = await self.get_config(project, exp)
             except FileNotFoundError:
                 pass
-            finally:
+            else:
                 public = config.get("exp_info", {}).get("public", False)
             experiments[exp] = {"public": public}
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -24,6 +24,7 @@ from .templatemapper import (
 from .filter import filter_heatmap, filter_regional_stats
 from ..exceptions import UnsupportedOperation
 from .cache import JSONLRUCache
+from ..routes import *
 
 logger = logging.getLogger(__name__)
 
@@ -37,101 +38,85 @@ class AerovalJsonFileDB(AerovalDB):
             self._basedir = str(Path(self._basedir))
 
         self.PATH_LOOKUP: dict[str, list[TemplateMapper]] = {
-            "/v0/glob_stats/{project}/{experiment}/{frequency}": [
+            ROUTE_GLOB_STATS: [
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/hm/glob_stats_{frequency}.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/regional_stats/{project}/{experiment}/{frequency}": [
+            ROUTE_REG_STATS: [
                 # Same as glob_stats
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/hm/glob_stats_{frequency}.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/heatmap/{project}/{experiment}/{frequency}": [
+            ROUTE_HEATMAP: [
                 # Same as glob_stats
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/hm/glob_stats_{frequency}.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/contour/{project}/{experiment}/{obsvar}/{model}": [
+            ROUTE_CONTOUR: [
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/contour/{obsvar}_{model}.geojson",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/ts/{project}/{experiment}/{location}/{network}/{obsvar}/{layer}": [
+            ROUTE_TIMESERIES: [
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/ts/{location}_{network}-{obsvar}_{layer}.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/experiments/{project}": [
-                PriorityDataVersionToTemplateMapper(["./{project}/experiments.json"])
-            ],
-            "/v0/config/{project}/{experiment}": [
-                PriorityDataVersionToTemplateMapper(
-                    ["./{project}/{experiment}/cfg_{project}_{experiment}.json"]
-                )
-            ],
-            "/v0/menu/{project}/{experiment}": [
-                DataVersionToTemplateMapper(
-                    "./{project}/{experiment}/menu.json",
-                    version_provider=self._get_version,
-                )
-            ],
-            "/v0/statistics/{project}/{experiment}": [
-                DataVersionToTemplateMapper(
-                    "./{project}/{experiment}/statistics.json",
-                    version_provider=self._get_version,
-                )
-            ],
-            "/v0/ranges/{project}/{experiment}": [
-                DataVersionToTemplateMapper(
-                    "./{project}/{experiment}/ranges.json",
-                    version_provider=self._get_version,
-                )
-            ],
-            "/v0/regions/{project}/{experiment}": [
-                DataVersionToTemplateMapper(
-                    "./{project}/{experiment}/regions.json",
-                    version_provider=self._get_version,
-                )
-            ],
-            "/v0/ts_weekly/{project}/{experiment}/{location}_{network}-{obsvar}_{layer}": [
+            ROUTE_TIMESERIES_WEEKLY: [
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/ts/diurnal/{location}_{network}-{obsvar}_{layer}.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/profiles/{project}/{experiment}/{location}/{network}/{obsvar}": [
+            ROUTE_EXPERIMENTS: [
+                PriorityDataVersionToTemplateMapper(["./{project}/experiments.json"])
+            ],
+            ROUTE_CONFIG: [
+                PriorityDataVersionToTemplateMapper(
+                    ["./{project}/{experiment}/cfg_{project}_{experiment}.json"]
+                )
+            ],
+            ROUTE_MENU: [
                 DataVersionToTemplateMapper(
-                    "./{project}/{experiment}/profiles/{location}_{network}-{obsvar}.json",
+                    "./{project}/{experiment}/menu.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/forecast/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}": [
+            ROUTE_STATISTICS: [
                 DataVersionToTemplateMapper(
-                    "./{project}/{experiment}/forecast/{region}_{network}-{obsvar}_{layer}.json",
+                    "./{project}/{experiment}/statistics.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/gridded_map/{project}/{experiment}/{obsvar}/{model}": [
+            ROUTE_RANGES: [
                 DataVersionToTemplateMapper(
-                    "./{project}/{experiment}/contour/{obsvar}_{model}.json",
+                    "./{project}/{experiment}/ranges.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/report/{project}/{experiment}/{title}": [
+            ROUTE_REGIONS: [
                 DataVersionToTemplateMapper(
-                    "./reports/{project}/{experiment}/{title}.json",
+                    "./{project}/{experiment}/regions.json",
                     version_provider=self._get_version,
                 )
             ],
-            "/v0/map/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}": [
+            ROUTE_MODELS_STYLE: [
+                PriorityDataVersionToTemplateMapper(
+                    [
+                        "./{project}/{experiment}/models-style.json",
+                        "./{project}/models-style.json",
+                    ]
+                )
+            ],
+            ROUTE_MAP: [
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/map/{network}-{obsvar}_{layer}_{model}-{modvar}_{time}.json",
                     min_version="0.13.2",
@@ -143,7 +128,7 @@ class AerovalJsonFileDB(AerovalDB):
                     version_provider=self._get_version,
                 ),
             ],
-            "/v0/scat/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}/{time}": [
+            ROUTE_SCATTER: [
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/scat/{network}-{obsvar}_{layer}_{model}-{modvar}_{time}.json",
                     min_version="0.13.2",
@@ -155,7 +140,13 @@ class AerovalJsonFileDB(AerovalDB):
                     version_provider=self._get_version,
                 ),
             ],
-            "/v0/hm_ts/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}": [
+            ROUTE_PROFILES: [
+                DataVersionToTemplateMapper(
+                    "./{project}/{experiment}/profiles/{location}_{network}-{obsvar}.json",
+                    version_provider=self._get_version,
+                )
+            ],
+            ROUTE_HEATMAP_TIMESERIES: [
                 DataVersionToTemplateMapper(
                     "./{project}/{experiment}/hm/ts/{region}-{network}-{obsvar}-{layer}.json",
                     min_version="0.13.2",  # https://github.com/metno/pyaerocom/blob/4478b4eafb96f0ca9fd722be378c9711ae10c1f6/setup.cfg
@@ -173,19 +164,29 @@ class AerovalJsonFileDB(AerovalDB):
                     version_provider=self._get_version,
                 ),
             ],
-            "/v0/model_style/{project}": [
-                PriorityDataVersionToTemplateMapper(
-                    [
-                        "./{project}/{experiment}/models-style.json",
-                        "./{project}/models-style.json",
-                    ]
+            ROUTE_FORECAST: [
+                DataVersionToTemplateMapper(
+                    "./{project}/{experiment}/forecast/{region}_{network}-{obsvar}_{layer}.json",
+                    version_provider=self._get_version,
+                )
+            ],
+            ROUTE_GRIDDED_MAP: [
+                DataVersionToTemplateMapper(
+                    "./{project}/{experiment}/contour/{obsvar}_{model}.json",
+                    version_provider=self._get_version,
+                )
+            ],
+            ROUTE_REPORT: [
+                DataVersionToTemplateMapper(
+                    "./reports/{project}/{experiment}/{title}.json",
+                    version_provider=self._get_version,
                 )
             ],
         }
 
         self.FILTERS: dict[str, Callable[..., Awaitable[Any]]] = {
-            "/v0/regional_stats/{project}/{experiment}/{frequency}": filter_regional_stats,
-            "/v0/heatmap/{project}/{experiment}/{frequency}": filter_heatmap,
+            ROUTE_REG_STATS: filter_regional_stats,
+            ROUTE_HEATMAP: filter_heatmap,
         }
 
     @async_and_sync
@@ -366,7 +367,7 @@ class AerovalJsonFileDB(AerovalDB):
         try:
             access_type = self._normalize_access_type(kwargs.pop("access_type", None))
             experiments = await self._get(
-                "/v0/experiments/{project}",
+                ROUTE_EXPERIMENTS,
                 {"project": project},
                 access_type=access_type,
             )
@@ -437,7 +438,7 @@ class AerovalJsonFileDB(AerovalDB):
         :param variable: Variable name.
         """
         return await self._get(
-            "/v0/regional_stats/{project}/{experiment}/{frequency}",
+            ROUTE_REG_STATS,
             {"project": project, "experiment": experiment, "frequency": frequency},
             access_type=kwargs.get("access_type", AccessType.OBJ),
             network=network,
@@ -467,13 +468,18 @@ class AerovalJsonFileDB(AerovalDB):
         :param time: Time.
         """
         return await self._get(
-            "/v0/heatmap/{project}/{experiment}/{frequency}",
+            ROUTE_HEATMAP,
             {"project": project, "experiment": experiment, "frequency": frequency},
             access_type=kwargs.get("access_type", AccessType.OBJ),
             region=region,
             time=time,
             cache=True,
         )
+
+    def list_glob_stats(
+        self, project: str, experiment: str
+    ) -> Generator[str, None, None]:
+        pass
 
     def list_timeseries(
         self, project: str, experiment: str
@@ -483,7 +489,7 @@ class AerovalJsonFileDB(AerovalDB):
                 os.path.join(
                     self._basedir,
                     self._get_template(
-                        "/v0/ts/{project}/{experiment}/{location}/{network}/{obsvar}/{layer}",
+                        ROUTE_TIMESERIES,
                         {"project": project, "experiment": experiment},
                     ),  # type: ignore
                 )

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -37,6 +37,9 @@ class AerovalJsonFileDB(AerovalDB):
         if isinstance(self._basedir, str):
             self._basedir = str(Path(self._basedir))
 
+        if not os.path.exists(self._basedir):
+            os.makedirs(self._basedir)
+
         self.PATH_LOOKUP: dict[str, list[TemplateMapper]] = {
             ROUTE_GLOB_STATS: [
                 DataVersionToTemplateMapper(
@@ -346,16 +349,6 @@ class AerovalJsonFileDB(AerovalDB):
         logger.debug(f"Mapped route {route} / { route_args} to file {file_path}.")
 
         await self.put_by_uuid(obj, file_path)
-        # return
-        # if not os.path.exists(os.path.dirname(file_path)):
-        #    os.makedirs(os.path.dirname(file_path))
-
-    #
-    # if isinstance(obj, str):
-    #    json = obj
-    # else:
-    #    json = orjson.dumps(obj)#with open(file_path, "wb") as f:
-    #    f.write(json)
 
     @async_and_sync
     async def get_experiments(self, project: str, /, *args, exp_order=None, **kwargs):

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -546,6 +546,9 @@ class AerovalJsonFileDB(AerovalDB):
         project_path = os.path.join(self._basedir, project)
         experiments = []
 
+        if not os.path.exists(project_path):
+            return []
+
         for f in os.listdir(project_path):
             if not has_results:
                 if os.path.isdir(os.path.join(project_path, f)):

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -567,7 +567,11 @@ class AerovalJsonFileDB(AerovalDB):
 
     @async_and_sync
     async def get_by_uuid(
-        self, uuid: str, /, access_type: str | AccessType, cache: bool = False
+        self,
+        uuid: str,
+        /,
+        access_type: str | AccessType = AccessType.OBJ,
+        cache: bool = False,
     ):
         uuid = get_uuid(uuid)
         if not uuid.startswith(self._basedir):

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -479,7 +479,20 @@ class AerovalJsonFileDB(AerovalDB):
     def list_glob_stats(
         self, project: str, experiment: str
     ) -> Generator[str, None, None]:
-        pass
+        template = str(
+            os.path.realpath(
+                os.path.join(
+                    self._basedir,
+                    self._get_template(
+                        ROUTE_GLOB_STATS, {"project": project, "experiment": experiment}
+                    ),  # type: ignore
+                )
+            )
+        )
+        glb = template.replace("{frequency}", "*")
+
+        for f in glob.glob(glb):
+            yield f
 
     def list_timeseries(
         self, project: str, experiment: str
@@ -500,6 +513,31 @@ class AerovalJsonFileDB(AerovalDB):
             .replace("{network}", "*")
             .replace("{obsvar}", "*")
             .replace("{layer}", "*")
+        )
+        glb = glb.format(project=project, experiment=experiment)
+
+        for f in glob.glob(glb):
+            yield f
+
+    def list_map(self, project: str, experiment: str) -> Generator[str, None, None]:
+        template = str(
+            os.path.realpath(
+                os.path.join(
+                    self._basedir,
+                    self._get_template(
+                        ROUTE_MAP,
+                        {"project": project, "experiment": experiment},
+                    ),  # type: ignore
+                )
+            )
+        )
+        glb = (
+            template.replace("{network}", "*")
+            .replace("{obsvar}", "*")
+            .replace("{layer}", "*")
+            .replace("{model}", "*")
+            .replace("{modvar}", "*")
+            .replace("{time}", "*")
         )
         glb = glb.format(project=project, experiment=experiment)
 

--- a/src/aerovaldb/routes.py
+++ b/src/aerovaldb/routes.py
@@ -1,0 +1,47 @@
+ROUTE_GLOB_STATS = "/v0/glob_stats/{project}/{experiment}/{frequency}"
+
+ROUTE_REG_STATS = "/v0/regional_stats/{project}/{experiment}/{frequency}"
+
+ROUTE_HEATMAP = "/v0/heatmap/{project}/{experiment}/{frequency}"
+
+ROUTE_CONTOUR = "/v0/contour/{project}/{experiment}/{obsvar}/{model}"
+
+ROUTE_TIMESERIES = "/v0/ts/{project}/{experiment}/{location}/{network}/{obsvar}/{layer}"
+
+ROUTE_TIMESERIES_WEEKLY = (
+    "/v0/ts_weekly/{project}/{experiment}/{location}_{network}-{obsvar}_{layer}"
+)
+
+ROUTE_EXPERIMENTS = "/v0/experiments/{project}"
+
+ROUTE_CONFIG = "/v0/config/{project}/{experiment}"
+
+ROUTE_MENU = "/v0/menu/{project}/{experiment}"
+
+ROUTE_STATISTICS = "/v0/statistics/{project}/{experiment}"
+
+ROUTE_RANGES = "/v0/ranges/{project}/{experiment}"
+
+ROUTE_REGIONS = "/v0/regions/{project}/{experiment}"
+
+ROUTE_MODELS_STYLE = "/v0/model_style/{project}"
+
+ROUTE_MAP = "/v0/map/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}"
+
+ROUTE_SCATTER = (
+    "/v0/scat/{project}/{experiment}/{network}/{obsvar}/{layer}/{model}/{modvar}/{time}"
+)
+
+ROUTE_PROFILES = "/v0/profiles/{project}/{experiment}/{location}/{network}/{obsvar}"
+
+ROUTE_HEATMAP_TIMESERIES = (
+    "/v0/hm_ts/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}"
+)
+
+ROUTE_FORECAST = (
+    "/v0/forecast/{project}/{experiment}/{region}/{network}/{obsvar}/{layer}"
+)
+
+ROUTE_GRIDDED_MAP = "/v0/gridded_map/{project}/{experiment}/{obsvar}/{model}"
+
+ROUTE_REPORT = "/v0/report/{project}/{experiment}/{title}"

--- a/tests/jsondb/test_jsonfiledb.py
+++ b/tests/jsondb/test_jsonfiledb.py
@@ -197,7 +197,7 @@ def test_getter_sync(resource: str, fun: str, args: list, kwargs: dict, expected
 @pytest.mark.asyncio
 async def test_file_does_not_exist():
     with aerovaldb.open("json_files:./tests/test-db/json") as db:
-        with pytest.raises(aerovaldb.FileDoesNotExist):
+        with pytest.raises(FileNotFoundError):
             await db.get_config(
                 "non-existent-project",
                 "experiment",


### PR DESCRIPTION
- Implements `list_glob_stats()` which can be used to iterate over all globstats json files.
- Implements `list_map()` which can be used to iterate over all map json files.
- Use `FileNotFoundError` instead of custom exception.
- Reintroduce `put_experiments()`
- Allows specifying a default return value which will be returned instead of raising an exception if no file exists by passing `default = ...` to any get call.
- Refactor to use `get_by_uuid` and `put_by_uuid` in the `_get`/`_put` which should prevent subtle differences in behaviour of eg. caching, and access_mode with different implementations.