### PR TITLE
Add option to toggle async io in open()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,39 @@ About
 
 TBD
 
+Usage Example
+============
+
+Reading
+------------
+
+   .. code-block:: python
+      import aerovaldb
+
+      with aerovaldb.open('json_files:path/to/data/') as db:
+          try:
+              fh = db.get_map(*args, access_type=aerovaldb.AccessType.FILE_PATH)
+              # ... sendfile of filehandle
+          except FileNotFoundError as e:
+              json = db.get_map(*args, access_type=aerovaldb.AccessType.JSON_STR)
+              # ... send json string to client
+
+Writing
+------------
+
+   .. code-block:: python
+      import aerovaldb
+      import json
+      
+      with aerovaldb.open('json_files:path/to/data/') as db:
+          db.put
+          obj = {"data": "Some test data"}
+          json_str = "{ 'data': 'Some test data' }"
+          db.put_map(json_str) # String is assumed to be json string and stored directly.
+      
+          db.put_map(obj) # Otherwise serialized object is stored.
+
+
 .. toctree::
    :maxdepth: 1
    :caption: Contents:

--- a/scripts/aiofile_benchmark.py
+++ b/scripts/aiofile_benchmark.py
@@ -1,0 +1,59 @@
+import aiofile
+import time
+import random
+import os
+import aiofile
+import asyncio
+
+
+def generate_test_file(fp: str, /, size: int):
+    with open(fp, "w") as f:
+        for i in range(size):
+            bytes = random.randbytes(1024)
+            f.write(bytes.hex())
+
+
+def generate_test_files():
+    if not os.path.exists("test-file-1kb"):
+        print("Generate 1kb test file")
+        generate_test_file("test-file-1kb", 1)
+
+    if not os.path.exists("test-file-100kb"):
+        print("Generate 100kb test file")
+        generate_test_file("test-file-100kb", 100)
+
+    if not os.path.exists("test-file-10000kb"):
+        print("Generate 10000kb test file")
+        generate_test_file("test-file-10000kb", 100000)
+
+    if not os.path.exists("test-file-250000kb"):
+        print("Generate 250000kb test file")
+        generate_test_file("test-file-250000kb", 250000)
+
+
+generate_test_files()
+
+for fp in (
+    "test-file-1kb",
+    "test-file-100kb",
+    "test-file-10000kb",
+    "test-file-250000kb",
+):
+    print(f"Testing file {fp}")
+    print(f" Testing synchronous read")
+    start_time = time.perf_counter()
+    for _ in range(10):
+        with open(fp, "r") as f:
+            f.read()
+    print(f" Time elapsed: {time.perf_counter()-start_time:.2f}s")
+
+    async def async_read(fpath: str):
+        for _ in range(10):
+            async with aiofile.async_open(fpath) as f:
+                await f.read()
+
+    print(f" Testing asynchronous read")
+    start_time = time.perf_counter()
+    for _ in range(10):
+        asyncio.run(async_read(fp))
+    print(f" Time elapsed: {time.perf_counter()-start_time:.2f}s")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.6.dev0
+version = 0.0.6
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.6
+version = 0.0.7.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -30,8 +30,13 @@ logger = logging.getLogger(__name__)
 
 
 class AerovalJsonFileDB(AerovalDB):
-    def __init__(self, basedir: str | Path):
-        self._cache = JSONLRUCache(max_size=64)
+    def __init__(self, basedir: str | Path, /, use_async: bool = False):
+        """
+        :param basedir The root directory where aerovaldb will look for files.
+        :param asyncio Whether to use asynchronous io to read and store files.
+        """
+        self._asyncio = use_async
+        self._cache = JSONLRUCache(max_size=64, asyncio=self._asyncio)
 
         self._basedir = os.path.realpath(basedir)
         if isinstance(self._basedir, str):

--- a/src/aerovaldb/plugins.py
+++ b/src/aerovaldb/plugins.py
@@ -52,6 +52,8 @@ def open(resource, /, use_async: bool = False) -> AerovalDB:
         - 'entrypoint:path', with path being the location where the database should be generated
         - 'path', with path containing either an aerovaldb.cfg configuration
         - or path being a json_files dabasase
+    :param use_async : If true, aiofile will be used to read files, otherwise files will be read
+        synchronously.
     :return: an implementation-object of AerovalDB openend to a location
     """
 

--- a/src/aerovaldb/plugins.py
+++ b/src/aerovaldb/plugins.py
@@ -44,7 +44,7 @@ def list_engines() -> dict[str, AerovalDB]:
     return _build_db_engines(entrypoints)
 
 
-def open(resource) -> AerovalDB:
+def open(resource, /, use_async: bool = False) -> AerovalDB:
     """open an AerovalDB directly, sending args and kwargs
     directly to the `AervoalDB()` function
 
@@ -66,4 +66,4 @@ def open(resource) -> AerovalDB:
 
     aerodb = list_engines()[name]
 
-    return aerodb(path)  # type: ignore
+    return aerodb(path, use_async=use_async)  # type: ignore

--- a/tests/jsondb/test_jsonfiledb.py
+++ b/tests/jsondb/test_jsonfiledb.py
@@ -169,7 +169,7 @@ async def test_getter(resource: str, fun: str, args: list, kwargs: dict, expecte
     """
     This test tests that data is read as expected from a static, fixed database.
     """
-    with aerovaldb.open(resource) as db:
+    with aerovaldb.open(resource, use_async=True) as db:
         f = getattr(db, fun)
 
         if kwargs is not None:
@@ -183,7 +183,7 @@ async def test_getter(resource: str, fun: str, args: list, kwargs: dict, expecte
 @pytest.mark.parametrize("resource", (("json_files:./tests/test-db/json",)))
 @pytest.mark.parametrize(*get_parameters)
 def test_getter_sync(resource: str, fun: str, args: list, kwargs: dict, expected):
-    with aerovaldb.open(resource) as db:
+    with aerovaldb.open(resource, use_async=False) as db:
         f = getattr(db, fun)
 
         if kwargs is not None:


### PR DESCRIPTION
Adds an option to `aerovaldb.open()` to specify whether to read files asynchronously (aiofile) or synchronously.