### PR TITLE
Various fixes required for Pyaerocom writing / locking

### DIFF
--- a/docs/locking.rst
+++ b/docs/locking.rst
@@ -5,6 +5,8 @@ To ensure consistent writes, aerovaldb provides a locking mechanism which can be
 
 For :class:`AerovalJsonFileDB` the locking mechanism uses a folder of lock files (`~/.aerovaldb/` by default) to coordinate the lock. It is important that the file system where the lock files are stored supports `fcntl <https://linux.die.net/man/2/fcntl>`.
 
+By default locking is disabled as it has large effect on performance. To enable, set the environment variable `AVDB_USE_LOCKING=1`.
+
 Overriding the lock-file directory
 ----------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ python_version = >=3.9
 install_requires =
     importlib-metadata >= 3.6; python_version < "3.10"
     orjson
+    simplejson
     aiofile
     async_lru
     packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ url = https://github.com/metno/aerovaldb
 python_version = >=3.9
 install_requires =
     importlib-metadata >= 3.6; python_version < "3.10"
-    numpy
     orjson
     aiofile
     async_lru

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ url = https://github.com/metno/aerovaldb
 python_version = >=3.9
 install_requires =
     importlib-metadata >= 3.6; python_version < "3.10"
+    numpy
     orjson
     aiofile
     async_lru

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.10.dev0
+version = 0.0.10
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.9
+version = 0.0.10.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.9.dev0
+version = 0.0.9
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.10
+version = 0.0.11.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -8,6 +8,7 @@ from typing import Callable, Awaitable, Any, Generator
 import orjson
 from async_lru import alru_cache
 from packaging.version import Version
+from pkg_resources import get_distribution  # type: ignore
 
 from aerovaldb.aerovaldb import AerovalDB
 from aerovaldb.exceptions import UnusedArguments, TemplateNotFound
@@ -232,7 +233,14 @@ class AerovalJsonFileDB(AerovalDB):
             version_str = config["exp_info"]["pyaerocom_version"]
             version = Version(version_str)
         except KeyError:
-            version = Version("0.0.1")
+            try:
+                # If pyaerocom is installed in the current environment, but no config has
+                # been written, we use the version of the installed pyaerocom. This is
+                # important for tests to work correctly, and for files to be written
+                # correctly if the config file happens to be written after data files.
+                version = Version(get_distribution("pyaerocom").version)
+            except KeyError:
+                version = Version("0.0.1")
 
         return version
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -29,18 +29,20 @@ from .cache import JSONLRUCache
 from ..routes import *
 from ..lock.lock import FakeLock, FileLock
 from hashlib import md5
+import simplejson  # type: ignore
 
 logger = logging.getLogger(__name__)
 
 
-def json_dumps_wrapper(obj):
+def json_dumps_wrapper(obj, **kwargs):
     """
-    Wrapper which calls orjson.dumps with the correct options, known to work for objects
+    Wrapper which calls simple.json with the correct options, known to work for objects
     returned by Pyaerocom.
     """
-    return orjson.dumps(
-        obj, default=default_serialization, option=orjson.OPT_NON_STR_KEYS
-    )
+    return simplejson.dumps(obj, allow_nan=True, **kwargs)
+    # return orjson.dumps(
+    #    obj, default=default_serialization, option=orjson.OPT_NON_STR_KEYS
+    # )
 
 
 class AerovalJsonFileDB(AerovalDB):
@@ -635,10 +637,10 @@ class AerovalJsonFileDB(AerovalDB):
         if not os.path.exists(os.path.dirname(uri)):
             os.makedirs(os.path.dirname(uri))
         if isinstance(obj, str):
-            json = obj.encode()
+            json = obj
         else:
             json = json_dumps_wrapper(obj)
-        with open(uri, "wb") as f:
+        with open(uri, "w") as f:
             f.write(json)
 
     def _get_lock_file(self) -> str:

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 
 from aerovaldb.aerovaldb import AerovalDB
 from aerovaldb.exceptions import UnusedArguments, TemplateNotFound
+from aerovaldb.serialization.default_serialization import default_serialization
 from aerovaldb.types import AccessType
 
 from ..utils import async_and_sync
@@ -326,7 +327,7 @@ class AerovalJsonFileDB(AerovalDB):
                 data = filter_func(data, **filter_vars)
 
                 if access_type == AccessType.JSON_STR:
-                    data = orjson.dumps(data)
+                    data = orjson.dumps(data, default=default_serialization)
 
                 return data
 
@@ -391,7 +392,7 @@ class AerovalJsonFileDB(AerovalDB):
             )
 
         if access_type == AccessType.JSON_STR:
-            json = orjson.dumps(experiments)
+            json = orjson.dumps(experiments, default=default_serialization)
             return json
 
         return experiments
@@ -594,7 +595,7 @@ class AerovalJsonFileDB(AerovalDB):
 
         if access_type == AccessType.JSON_STR:
             raw = await self._cache.get_json(uri, no_cache=not cache)
-            return orjson.dumps(raw)
+            return orjson.dumps(raw, default_serialization=default_serialization)
 
         raw = await self._cache.get_json(uri, no_cache=not cache)
 
@@ -616,7 +617,7 @@ class AerovalJsonFileDB(AerovalDB):
         if isinstance(obj, str):
             json = obj.encode()
         else:
-            json = orjson.dumps(obj)
+            json = orjson.dumps(obj, default=default_serialization)
         with open(uri, "wb") as f:
             f.write(json)
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -34,9 +34,9 @@ import simplejson  # type: ignore
 logger = logging.getLogger(__name__)
 
 
-def json_dumps_wrapper(obj, **kwargs):
+def json_dumps_wrapper(obj, **kwargs) -> str:
     """
-    Wrapper which calls simplejson with the correct options, known to work for objects
+    Wrapper which calls simplejson.dumps with the correct options, known to work for objects
     returned by Pyaerocom.
     """
     return simplejson.dumps(obj, allow_nan=True, **kwargs)

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -32,6 +32,16 @@ from hashlib import md5
 logger = logging.getLogger(__name__)
 
 
+def json_dumps_wrapper(obj):
+    """
+    Wrapper which calls orjson.dumps with the correct options, known to work for objects
+    returned by Pyaerocom.
+    """
+    return orjson.dumps(
+        obj, default=default_serialization, option=orjson.OPT_NON_STR_KEYS
+    )
+
+
 class AerovalJsonFileDB(AerovalDB):
     def __init__(self, basedir: str | Path, /, use_async: bool = False):
         """
@@ -327,7 +337,7 @@ class AerovalJsonFileDB(AerovalDB):
                 data = filter_func(data, **filter_vars)
 
                 if access_type == AccessType.JSON_STR:
-                    data = orjson.dumps(data, default=default_serialization)
+                    data = json_dumps_wrapper(data)
 
                 return data
 
@@ -392,7 +402,7 @@ class AerovalJsonFileDB(AerovalDB):
             )
 
         if access_type == AccessType.JSON_STR:
-            json = orjson.dumps(experiments, default=default_serialization)
+            json = json_dumps_wrapper(experiments)
             return json
 
         return experiments
@@ -595,7 +605,7 @@ class AerovalJsonFileDB(AerovalDB):
 
         if access_type == AccessType.JSON_STR:
             raw = await self._cache.get_json(uri, no_cache=not cache)
-            return orjson.dumps(raw, default_serialization=default_serialization)
+            return json_dumps_wrapper(raw)
 
         raw = await self._cache.get_json(uri, no_cache=not cache)
 
@@ -617,7 +627,7 @@ class AerovalJsonFileDB(AerovalDB):
         if isinstance(obj, str):
             json = obj.encode()
         else:
-            json = orjson.dumps(obj, default=default_serialization)
+            json = json_dumps_wrapper(obj)
         with open(uri, "wb") as f:
             f.write(json)
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -650,7 +650,11 @@ class AerovalJsonFileDB(AerovalDB):
         return lock_file
 
     def lock(self):
-        real_lock = bool(os.environ.get("AVDB_USE_LOCKING", False))
+        use_locking = os.environ.get("AVDB_USE_LOCKING", "")
+        if use_locking == "0" or use_locking == "":
+            real_lock = False
+        else:
+            real_lock = True
 
         if real_lock:
             return FileLock(self._get_lock_file())

--- a/src/aerovaldb/lock/lock.py
+++ b/src/aerovaldb/lock/lock.py
@@ -62,7 +62,6 @@ class FakeLock(AerovaldbLock):
     def release(self):
         self._acquired = False
 
-    @abstractmethod
     def is_locked(self) -> bool:
         return self._acquired
 

--- a/src/aerovaldb/lock/lock.py
+++ b/src/aerovaldb/lock/lock.py
@@ -45,6 +45,28 @@ class AerovaldbLock(ABC):
         pass
 
 
+class FakeLock(AerovaldbLock):
+    """
+    A lock class which does not lock anything. Useful for
+    disabling locking when it is not really needed, but leave
+    code written for using locking.
+    """
+
+    def __init__(self):
+        logger.debug("Initializing FAKE lock")
+        self.acquire()
+
+    def acquire(self):
+        self._acquired = True
+
+    def release(self):
+        self._acquired = False
+
+    @abstractmethod
+    def is_locked(self) -> bool:
+        return self._acquired
+
+
 class FileLock(AerovaldbLock):
     def __init__(self, lock_file: str | pathlib.Path):
         logger.debug("Initializing lock with lockfile %s", lock_file)

--- a/src/aerovaldb/serialization/default_serialization.py
+++ b/src/aerovaldb/serialization/default_serialization.py
@@ -1,8 +1,15 @@
-import numpy as np
+import sys
+
+try:
+    import numpy as np
+except ImportError:
+    # Only needed for serialization typing.
+    pass
 
 
 def default_serialization(val):
-    if isinstance(val, np.float64):
-        return float(val)
+    if "numpy" in sys.modules:
+        if isinstance(val, np.float64):
+            return float(val)
 
-    return str(val)
+    raise TypeError

--- a/src/aerovaldb/serialization/default_serialization.py
+++ b/src/aerovaldb/serialization/default_serialization.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+
+def default_serialization(val):
+    if isinstance(val, np.float64):
+        return float(val)
+
+    return str(val)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["AVDB_USE_LOCKING"] = "1"

--- a/tests/jsondb/test_lock.py
+++ b/tests/jsondb/test_lock.py
@@ -1,8 +1,9 @@
+import os
 import pytest
 from multiprocessing import Process
 
 import asyncio
-from aerovaldb.lock.lock import FileLock
+from aerovaldb.lock.lock import FileLock, FakeLock
 import aerovaldb
 from pathlib import Path
 import logging
@@ -10,6 +11,18 @@ import logging
 pytest_plugins = ("pytest_asyncio",)
 
 logger = logging.getLogger(__name__)
+
+
+def test_fake_lock():
+    os.environ["AVDB_USE_LOCKING"] = "0"
+    with aerovaldb.open("json_files:tests/test-db/json") as db:
+        assert isinstance(db.lock(), FakeLock)
+
+
+def test_file_lock():
+    os.environ["AVDB_USE_LOCKING"] = "1"
+    with aerovaldb.open("json_files:tests/test-db/json") as db:
+        assert isinstance(db.lock(), FileLock)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change Summary

Implements a number of fixes required for https://github.com/metno/pyaerocom/pull/1273:

- Fixes `TypeError: Type is not JSON serializable: numpy.float64` when serializing numpy floats.
- Fixes dict-key must be str error.
- Aerovaldb defaulting to using the oldest version based filepath template string if cfg file was not written. It will now first try the currently installed version of pyaerocom, if it exists (Needed for files to be written correctly in tests, and other situations where no config file has been written).
- Locking will be enabled based on environment variable `AVDB_USE_LOCKING`. This allows eliminating the performance overhead of locking in context where this is known to be safe (eg. tests or non-parallellized workloads).

## Todo
- [x] Make numpy an optional dependency.
- [x] Documentation and tests for locking changes.

## Related issue number

https://github.com/metno/pyaerocom/pull/1273

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
