### PR TITLE
Allow folder path as resource string

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.12
+version = 0.0.13.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.12.dev0
+version = 0.0.12
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/__init__.py
+++ b/src/aerovaldb/__init__.py
@@ -5,3 +5,4 @@ __version__ = metadata.version(__package__)
 from .exceptions import *
 from .plugins import list_engines, open
 from .types import *
+from .aerovaldb import AerovalDB

--- a/src/aerovaldb/plugins.py
+++ b/src/aerovaldb/plugins.py
@@ -50,8 +50,9 @@ def open(resource, /, use_async: bool = False) -> AerovalDB:
 
     :param resource: the resource-name for the database. The resource can be
         - 'entrypoint:path', with path being the location where the database should be generated
-        - 'path', with path containing either an aerovaldb.cfg configuration
-        - or path being a json_files dabasase
+        (eg. 'json_files:.')
+        - 'path', with path containing either an aerovaldb.cfg (Not yet implemented) configuration
+        or path being a json_files dabasase (for example, '.' is equivalent to 'json_files:.')
     :param use_async : If true, aiofile will be used to read files, otherwise files will be read
         synchronously.
     :return: an implementation-object of AerovalDB openend to a location

--- a/src/aerovaldb/plugins.py
+++ b/src/aerovaldb/plugins.py
@@ -57,12 +57,19 @@ def open(resource, /, use_async: bool = False) -> AerovalDB:
     :return: an implementation-object of AerovalDB openend to a location
     """
 
-    parts = resource.split(":")
-    if len(parts) > 1:
-        name = parts[0]
-        path = ":".join(parts[1:])
+    if ":" in resource:
+        parts = resource.split(":")
+        if len(parts) > 1:
+            name = parts[0]
+            path = ":".join(parts[1:])
+        else:
+            # TODO check if path contains a aerovaldb cfg file
+            name = "json_files"
+            path = resource
     else:
-        # TODO check if path contains a aerovaldb cfg file
+        # Assume directory and json.
+        # TODO: In the future this should differentiate based on file path, eg. folder->json_files
+        # .sqlite-> SqliteDB, etc.
         name = "json_files"
         path = resource
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,9 +1,23 @@
 import pytest
+import os
 
 import aerovaldb
+from aerovaldb.jsondb.jsonfiledb import AerovalJsonFileDB
 
 
 def test_plugins():
     engines = aerovaldb.list_engines()
     print(engines)
     assert len(engines) >= 1
+
+
+def test_open_1():
+    with aerovaldb.open("json_files:.") as db:
+        assert isinstance(db, AerovalJsonFileDB)
+        assert os.path.realpath(db._basedir) == os.path.realpath(".")
+
+
+def test_open_2():
+    with aerovaldb.open(".") as db:
+        assert isinstance(db, AerovalJsonFileDB)
+        assert os.path.realpath(db._basedir) == os.path.realpath(".")


### PR DESCRIPTION
## Change Summary

Allows folder path as resource string to aerovaldb.open().

Tests general parsing of resource string for different cases.

## Related issue number

https://github.com/metno/pyaerocom/pull/1273

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
