### PR TITLE
Fix json nan-serialization

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.14.dev0
+version = 0.0.14
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.0.14
+version = 0.0.15.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -37,8 +37,10 @@ def json_dumps_wrapper(obj, **kwargs) -> str:
     """
     Wrapper which calls simplejson.dumps with the correct options, known to work for objects
     returned by Pyaerocom.
+
+    This ensures that nan values are serialized as null to be compliant with the json standard.
     """
-    return simplejson.dumps(obj, allow_nan=True, **kwargs)
+    return simplejson.dumps(obj, ignore_nan=True, **kwargs)
 
 
 class AerovalJsonFileDB(AerovalDB):

--- a/tests/jsondb/test_jsonfiledb.py
+++ b/tests/jsondb/test_jsonfiledb.py
@@ -356,6 +356,8 @@ def test_write_and_read_of_nan(tmp_path):
 
         read = db.get_by_uri("./test")
 
+        # See Additional Notes on #59
+        # https://github.com/metno/aerovaldb/pull/59
         assert read["value"] is None
 
 

--- a/tests/jsondb/test_jsonfiledb.py
+++ b/tests/jsondb/test_jsonfiledb.py
@@ -356,7 +356,7 @@ def test_write_and_read_of_nan(tmp_path):
 
         read = db.get_by_uri("./test")
 
-        assert math.isnan(read["value"])
+        assert read["value"] is None
 
 
 def test_exception_on_unexpected_args():


### PR DESCRIPTION
## Change Summary

Use `ignore_nan=True` when writing json, which writes compliant json and fixes an issue where aeroval-web can't parse generated json.

## Related issue number

https://github.com/metno/pyaerocom/issues/1288

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review

## Additional Notes
This introduces a potential issue in that the data written by aerovaldb will not be the same when read in for nan values. aerovaldb writes nan as null, then reads null as `None` when reading. AFAICT this matches the old behavior of pyaerocom as seen in the [`write_json`](https://github.com/metno/pyaerocom/blob/2dad9c7890096535c9ae4ad23915150e1198ad99/pyaerocom/aeroval/json_utils.py#L72) and [`read_json`](https://github.com/metno/pyaerocom/blob/2dad9c7890096535c9ae4ad23915150e1198ad99/pyaerocom/aeroval/json_utils.py#L54) methods respectively, so I am leaving this as is for now.