### PR TITLE
Adds log message to indicate locking status, validates parameters and improves environment variable bool parsing.

### DIFF
--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -52,10 +52,9 @@ class AerovalJsonFileDB(AerovalDB):
         self._use_real_lock = str_to_bool(
             os.environ.get("AVDB_USE_LOCKING", ""), default=False
         )
-        if self._use_real_lock:
-            logger.info("Locking enabled.")
-        else:
-            logger.info("Locking disabled.")
+        logger.info(
+            f"Initializing aerovaldb for '{basedir}' with locking {self._use_real_lock}"
+        )
 
         self._asyncio = use_async
         self._cache = JSONLRUCache(max_size=64, asyncio=self._asyncio)

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -325,7 +325,7 @@ class AerovalJsonFileDB(AerovalDB):
             )
         logger.debug(f"Fetching data for {route}.")
         substitutions = route_args | kwargs
-        map(validate_filename_component, substitutions)
+        map(validate_filename_component, substitutions.values())
 
         path_template = await self._get_template(route, substitutions)
         logger.debug(f"Using template string {path_template}")
@@ -377,7 +377,7 @@ class AerovalJsonFileDB(AerovalDB):
             )
 
         substitutions = route_args | kwargs
-        map(validate_filename_component, substitutions)
+        map(validate_filename_component, substitutions.values())
         path_template = await self._get_template(route, substitutions)
         relative_path = path_template.format(**substitutions)
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -14,7 +14,7 @@ from aerovaldb.exceptions import UnusedArguments, TemplateNotFound
 from aerovaldb.serialization.default_serialization import default_serialization
 from aerovaldb.types import AccessType
 
-from ..utils import async_and_sync
+from ..utils import async_and_sync, str_to_bool
 from .uri import get_uri
 from .templatemapper import (
     TemplateMapper,
@@ -49,13 +49,13 @@ class AerovalJsonFileDB(AerovalDB):
         :param basedir The root directory where aerovaldb will look for files.
         :param asyncio Whether to use asynchronous io to read and store files.
         """
-        use_locking = os.environ.get("AVDB_USE_LOCKING", "")
-        if use_locking == "0" or use_locking == "":
-            logger.info("Locking disabled.")
-            self._use_real_lock = False
-        else:
+        self._use_real_lock = str_to_bool(
+            os.environ.get("AVDB_USE_LOCKING", ""), default=False
+        )
+        if self._use_real_lock:
             logger.info("Locking enabled.")
-            self._use_real_lock = True
+        else:
+            logger.info("Locking disabled.")
 
         self._asyncio = use_async
         self._cache = JSONLRUCache(max_size=64, asyncio=self._asyncio)

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -14,7 +14,7 @@ from aerovaldb.exceptions import UnusedArguments, TemplateNotFound
 from aerovaldb.serialization.default_serialization import default_serialization
 from aerovaldb.types import AccessType
 
-from ..utils import async_and_sync, str_to_bool
+from ..utils import async_and_sync, str_to_bool, validate_filename_component
 from .uri import get_uri
 from .templatemapper import (
     TemplateMapper,
@@ -325,6 +325,8 @@ class AerovalJsonFileDB(AerovalDB):
             )
         logger.debug(f"Fetching data for {route}.")
         substitutions = route_args | kwargs
+        map(validate_filename_component, substitutions)
+
         path_template = await self._get_template(route, substitutions)
         logger.debug(f"Using template string {path_template}")
 
@@ -375,6 +377,7 @@ class AerovalJsonFileDB(AerovalDB):
             )
 
         substitutions = route_args | kwargs
+        map(validate_filename_component, substitutions)
         path_template = await self._get_template(route, substitutions)
         relative_path = path_template.format(**substitutions)
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -51,8 +51,10 @@ class AerovalJsonFileDB(AerovalDB):
         """
         use_locking = os.environ.get("AVDB_USE_LOCKING", "")
         if use_locking == "0" or use_locking == "":
+            logger.info("Locking disabled.")
             self._use_real_lock = False
         else:
+            logger.info("Locking enabled.")
             self._use_real_lock = True
 
         self._asyncio = use_async

--- a/src/aerovaldb/lock/lock.py
+++ b/src/aerovaldb/lock/lock.py
@@ -3,7 +3,7 @@ import logging
 import fcntl
 import asyncio
 import pathlib
-from ..utils import _has_async_loop
+from ..utils import has_async_loop
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ class FileLock(AerovaldbLock):
     def acquire(self):
         logger.debug("Acquiring lock with lockfile %s", self._lock_file)
 
-        if _has_async_loop():
+        if has_async_loop():
             task = asyncio.ensure_future(self._aiolock.acquire())
             asyncio.wait(task)
 

--- a/src/aerovaldb/utils/__init__.py
+++ b/src/aerovaldb/utils/__init__.py
@@ -1,0 +1,2 @@
+from .asyncio import async_and_sync, has_async_loop
+from .string_utils import str_to_bool

--- a/src/aerovaldb/utils/__init__.py
+++ b/src/aerovaldb/utils/__init__.py
@@ -1,2 +1,2 @@
 from .asyncio import async_and_sync, has_async_loop
-from .string_utils import str_to_bool
+from .string_utils import str_to_bool, validate_filename_component

--- a/src/aerovaldb/utils/asyncio.py
+++ b/src/aerovaldb/utils/asyncio.py
@@ -8,7 +8,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def _has_async_loop():
+def has_async_loop():
     is_async = False
     try:
         loop = asyncio.get_running_loop()
@@ -31,7 +31,7 @@ def async_and_sync(function: Callable[P, T]) -> Callable[P, T]:
 
     @functools.wraps(function)
     def async_and_sync_wrap(*args, **kwargs):
-        if _has_async_loop():
+        if has_async_loop():
             return function(*args, **kwargs)
         else:
             return asyncio.run(function(*args, **kwargs))

--- a/src/aerovaldb/utils/string_utils.py
+++ b/src/aerovaldb/utils/string_utils.py
@@ -1,6 +1,9 @@
 import re
 
 
+PATH_COMPONENT_PATTERN = re.compile(r"[\w.-]+")
+
+
 def str_to_bool(value: str, /, strict: bool = False, default: bool = False) -> bool:
     """
     Parses a string as a boolean, supporting various values. It is intended
@@ -48,5 +51,5 @@ def validate_filename_component(value: str) -> None:
     if not isinstance(value, str):
         raise ValueError(f"Expected str, got {type(value)}")
 
-    if not re.match("[\w.-]+", value):
+    if not re.match(PATH_COMPONENT_PATTERN, value):
         raise ValueError(f"'{value}' is not a valid file name component.")

--- a/src/aerovaldb/utils/string_utils.py
+++ b/src/aerovaldb/utils/string_utils.py
@@ -1,0 +1,29 @@
+def str_to_bool(value: str, /, strict: bool = False, default: bool = False) -> bool:
+    """
+    Parses a string as a boolean, supporting various values. It is intended
+    mainly for parsing environment variables.
+
+    Supports 1/0, true/false, t/f, yes/no, y/n (Case insensitive).
+
+    :param value : The string value to be converted.
+    :param strict : If true, ValueError is raised if an unrecognized value is encountered,
+    otherwise default is returned.
+    :param default : Returned if strict is disabled, for unrecognized values.
+    :raises ValueError
+        If value is not a string
+    :raises ValueError
+        If strict is true, and value does not match expected values.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"Expected str, got {type(value)}")
+
+    if value.lower() in ["1", "true", "t", "yes", "y"]:
+        return True
+
+    if value.lower() in ["0", "false", "f", "no", "n"]:
+        return False
+
+    if not strict:
+        return default
+
+    raise ValueError("Unexpected string '{value}'")

--- a/src/aerovaldb/utils/string_utils.py
+++ b/src/aerovaldb/utils/string_utils.py
@@ -51,5 +51,5 @@ def validate_filename_component(value: str) -> None:
     if not isinstance(value, str):
         raise ValueError(f"Expected str, got {type(value)}")
 
-    if not re.match(PATH_COMPONENT_PATTERN, value):
+    if not PATH_COMPONENT_PATTERN.match(value):
         raise ValueError(f"'{value}' is not a valid file name component.")

--- a/src/aerovaldb/utils/string_utils.py
+++ b/src/aerovaldb/utils/string_utils.py
@@ -1,3 +1,6 @@
+import re
+
+
 def str_to_bool(value: str, /, strict: bool = False, default: bool = False) -> bool:
     """
     Parses a string as a boolean, supporting various values. It is intended
@@ -27,3 +30,23 @@ def str_to_bool(value: str, /, strict: bool = False, default: bool = False) -> b
         return default
 
     raise ValueError("Unexpected string '{value}'")
+
+
+def validate_filename_component(value: str) -> None:
+    """
+    Checks if a file name component contains characters which should
+    not be included in the file path.
+
+    This is stricter than strictly speaking necessary but is suitable
+    for aerovaldb's use case.
+
+    :param value : The component to be validated.
+
+    :raises ValueError :
+        if value is not string or not a valid filename component
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"Expected str, got {type(value)}")
+
+    if not re.match("[\w.-]+", value):
+        raise ValueError(f"'{value}' is not a valid file name component.")

--- a/tests/utils/test_string_utils.py
+++ b/tests/utils/test_string_utils.py
@@ -1,0 +1,36 @@
+import pytest
+from aerovaldb.utils import str_to_bool
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        ("1", True),
+        ("0", False),
+        ("TrUe", True),
+        ("FaLsE", False),
+        ("T", True),
+        ("F", False),
+        ("YeS", True),
+        ("No", False),
+        ("Y", True),
+        ("F", False),
+    ),
+)
+def test_str_to_bool(value: str, expected: bool):
+    assert str_to_bool(value) == expected
+
+
+def test_str_to_bool_exception_1():
+    with pytest.raises(ValueError):
+        str_to_bool(None)
+
+
+def test_str_to_bool_exception_2():
+    with pytest.raises(ValueError):
+        str_to_bool("blah", strict=True)
+
+
+def test_str_to_bool_default():
+    assert str_to_bool("blah", default=True)
+    assert not str_to_bool("blah", default=False)

--- a/tests/utils/test_string_utils.py
+++ b/tests/utils/test_string_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from aerovaldb.utils import str_to_bool
+from aerovaldb.utils import str_to_bool, validate_filename_component
 
 
 @pytest.mark.parametrize(
@@ -34,3 +34,37 @@ def test_str_to_bool_exception_2():
 def test_str_to_bool_default():
     assert str_to_bool("blah", default=True)
     assert not str_to_bool("blah", default=False)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        pytest.param(
+            "test1234_",
+        ),
+        pytest.param(
+            "test-1234",
+        ),
+    ),
+)
+def test_validate_filename_component_valid(value: str):
+    validate_filename_component(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        pytest.param(
+            "%",
+        ),
+        pytest.param(
+            "/",
+        ),
+        pytest.param(
+            None,
+        ),
+    ),
+)
+def test_validate_filename_component_invalid(value):
+    with pytest.raises(ValueError):
+        validate_filename_component(value)


### PR DESCRIPTION
## Change Summary

- A log message will be displayed to indicate if locking is enabled, when initializing a db connection.
- Environment variable `AVDB_USE_LOCKING` now supports giving values in additional formats, including `yes`/`no`.
- API arguments are validated to ensure they don't contain certain characters (which caused files to be stored in the wrong place in some cases) (See #55)
- 

## Related issue number

closes #55

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
