### PR TITLE
Replace deprecated pkg_resources

### DIFF
--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -4,10 +4,10 @@ import os
 import shutil
 from pathlib import Path
 from typing import Callable, Awaitable, Any, Generator
+import importlib.metadata
 
 from async_lru import alru_cache
 from packaging.version import Version
-from pkg_resources import DistributionNotFound, get_distribution  # type: ignore
 
 from aerovaldb.aerovaldb import AerovalDB
 from aerovaldb.exceptions import UnusedArguments, TemplateNotFound
@@ -236,8 +236,8 @@ class AerovalJsonFileDB(AerovalDB):
                 # been written, we use the version of the installed pyaerocom. This is
                 # important for tests to work correctly, and for files to be written
                 # correctly if the config file happens to be written after data files.
-                version = Version(get_distribution("pyaerocom").version)
-            except DistributionNotFound:
+                version = Version(importlib.metadata.version("pyaerocom"))
+            except importlib.metadata.PackageNotFoundError:
                 version = Version("0.0.1")
             finally:
                 return version


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->
Replaces `pkg_resources` with `importlib.metadata`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

`pkg_resources` is not available on newer python versions

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
