### PR TITLE
Cache filtered endpoint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.2.5.dev0
+version = 0.2.5
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.2.5
+version = 0.2.6.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -35,7 +35,7 @@ def get_method(route):
                         )
             if len(args) > 0:
                 raise IndexError(f"{len(args)} superfluous positional args provided.")
-            return await self._get(route, route_args, *args, cache=False, **kwargs)
+            return await self._get(route, route_args, *args, **kwargs)
 
         return wrapper
 

--- a/src/aerovaldb/jsondb/cache.py
+++ b/src/aerovaldb/jsondb/cache.py
@@ -138,7 +138,7 @@ class LRUFileCache(BaseCache):
 
     @override
     def clear(self) -> None:
-        logger.debug("Cache invalidated.")
+        logger.debug("Cache cleared.")
 
         self._entries = defaultdict(lambda: None)
         self._queue = LRUQueue()
@@ -219,6 +219,7 @@ class LRUFileCache(BaseCache):
     def put(self, obj, *, key: str):
         abspath = self._canonical_file_path(key)
         self._put_entry(abspath, obj=obj)
+        logger.debug("%s of %s entries in cache", self.size, self._max_size)
 
     @override
     def evict(self, file_path: str | Path) -> None:
@@ -228,7 +229,7 @@ class LRUFileCache(BaseCache):
         :param file_path : The file path to invalidate cache for.
         """
         abspath = self._canonical_file_path(file_path)
-        logger.debug(f"Invalidating cache for file {abspath}.")
+        logger.debug(f"Clearing cache for file {abspath}.")
         if abspath in self._entries:
             del self._entries[abspath]
             self._queue.remove(abspath)
@@ -327,6 +328,8 @@ class KeyCacheDecorator(BaseCache):
         while self.size > self._max_size:
             key = self._queue.pop()  # type: ignore
             self.evict(str(key))
+
+        logger.debug("%s of %s entries in cache", self.size, self._max_size)
 
     @override
     def clear(self) -> None:

--- a/src/aerovaldb/jsondb/cache.py
+++ b/src/aerovaldb/jsondb/cache.py
@@ -11,6 +11,12 @@ logger = logging.getLogger(__name__)
 
 
 class CacheMissError(FileNotFoundError):
+    """
+    Raised by cache implementations when a cache miss occurs
+    that the implementation is unable to handle (by eg.
+    delegating it).
+    """
+
     pass
 
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -870,7 +870,7 @@ class AerovalJsonFileDB(AerovalDB):
                 else:
                     key = f"{file_path}::{timestep}"
 
-                result = simplejson.loads(self._cache.get(key))
+                result = simplejson.loads(self._cache.get(key), allow_nan=True)
             except CacheMissError:
                 result = await self._get(
                     ROUTE_CONTOUR,

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -130,7 +130,7 @@ class AerovalJsonFileDB(AerovalDB):
             ROUTE_MAP: filter_map,
         }
 
-    async def _load_json(
+    def _load_json(
         self,
         key,
         *,
@@ -251,7 +251,7 @@ class AerovalJsonFileDB(AerovalDB):
             if access_type == AccessType.CTIME:
                 return datetime.datetime.fromtimestamp(os.path.getctime(file_path))
 
-            return await self._load_json(
+            return self._load_json(
                 file_path, access_type=access_type, cache=use_caching
             )
 
@@ -267,11 +267,9 @@ class AerovalJsonFileDB(AerovalDB):
         key = f"{file_path}::{'/'.join(filter_params)}"
 
         try:
-            obj = await self._load_json(
-                key, access_type=AccessType.OBJ, cache=use_caching
-            )
+            obj = self._load_json(key, access_type=AccessType.OBJ, cache=use_caching)
         except CacheMissError:
-            obj = await self._load_json(file_path)
+            obj = self._load_json(file_path)
             obj = filter_func(obj, **filter_vars)
             if use_caching:
                 self._cache.put(json_dumps_wrapper(obj), key=key)


### PR DESCRIPTION
## Change Summary

Cache map endpoint (or really all filtered endpoints).

- Filtered endpoints will respect the `cache` argument to getter function calls, and use cached results if `cache=True`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
