### PR TITLE
Public API changes for v0.3.0

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,13 @@
+import warnings
+
+from pytest import PytestRemovedIn9Warning
+
 # Root level conftest to ignore scripts folder in doctests.
+warnings.filterwarnings(
+    "ignore", category=PytestRemovedIn9Warning, message=".*py.path.local.*"
+)
+
+
 def pytest_ignore_collect(path):
     if "scripts" in str(path):
         return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.2.6.dev0
+version = 0.3.0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.3.0
+version = 0.3.1.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -240,7 +240,7 @@ class AerovalDB(abc.ABC):
         model: str,
         /,
         *args,
-        timestep: str | None = None,
+        timestep: str,
         access_type: str | AccessType = AccessType.OBJ,
         cache: bool = False,
         default=None,

--- a/src/aerovaldb/jsondb/cache.py
+++ b/src/aerovaldb/jsondb/cache.py
@@ -151,6 +151,7 @@ class LRUFileCache(BaseCache):
         self._miss_count = 0
 
     @property
+    @override
     def hit_count(self) -> int:
         """Returns the number of cache hits since the last `invalidate_all()` call.
 
@@ -161,11 +162,13 @@ class LRUFileCache(BaseCache):
         return self._hit_count
 
     @property
+    @override
     def size(self) -> int:
         """Returns the current size of the cache in terms of number of elements."""
         return self._queue.size
 
     @property
+    @override
     def miss_count(self) -> int:
         """Returns the number of cache misses since the last `invalidate_all()` call.
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -49,7 +49,6 @@ class AerovalJsonFileDB(AerovalDB):
     def __init__(self, basedir: str | Path):
         """
         :param basedir The root directory where aerovaldb will look for files.
-        :param asyncio Whether to use asynchronous io to read and store files.
         """
         self._use_real_lock = str_to_bool(
             os.environ.get("AVDB_USE_LOCKING", ""), default=False

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -874,7 +874,7 @@ class AerovalJsonFileDB(AerovalDB):
         model: str,
         /,
         *args,
-        timestep: str | None = None,
+        timestep: str,
         access_type: str | AccessType = AccessType.OBJ,
         cache: bool = False,
         default=None,

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -9,7 +9,7 @@ from hashlib import md5
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-import filetype
+import filetype  # type: ignore
 import simplejson  # type: ignore
 from async_lru import alru_cache
 from packaging.version import Version
@@ -668,6 +668,7 @@ class AerovalJsonFileDB(AerovalDB):
         )
         return lock_file
 
+    @override
     def lock(self):
         if self._use_real_lock:
             return FileLock(self._get_lock_file())

--- a/src/aerovaldb/lock/lock.py
+++ b/src/aerovaldb/lock/lock.py
@@ -2,9 +2,15 @@ import asyncio
 import fcntl
 import logging
 import pathlib
+import sys
 from abc import ABC, abstractmethod
 
 from ..utils import has_async_loop, run_until_finished
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +63,15 @@ class FakeLock(AerovaldbLock):
         logger.debug("Initializing FAKE lock")
         self.acquire()
 
+    @override
     def acquire(self):
         self._acquired = True
 
+    @override
     def release(self):
         self._acquired = False
 
+    @override
     def is_locked(self) -> bool:
         return self._acquired
 
@@ -75,6 +84,7 @@ class FileLock(AerovaldbLock):
         self._aiolock = asyncio.Lock()
         self.acquire()
 
+    @override
     def acquire(self):
         logger.debug("Acquiring lock with lockfile %s", self._lock_file)
 
@@ -84,6 +94,7 @@ class FileLock(AerovaldbLock):
         fcntl.lockf(self._lock_handle, fcntl.LOCK_EX)
         self._acquired = True
 
+    @override
     def release(self):
         logger.debug("Releasing lock with lockfile %s", self._lock_file)
 
@@ -92,5 +103,6 @@ class FileLock(AerovaldbLock):
         if self._aiolock.locked():
             self._aiolock.release()
 
+    @override
     def is_locked(self) -> bool:
         return self._acquired

--- a/src/aerovaldb/plugins.py
+++ b/src/aerovaldb/plugins.py
@@ -45,7 +45,7 @@ def list_engines() -> dict[str, AerovalDB]:
     return _build_db_engines(entrypoints)
 
 
-def open(resource, /, use_async: bool = False) -> AerovalDB:
+def open(resource) -> AerovalDB:
     """Open an AerovalDB instance, sending args and kwargs
     directly to the `AervoalDB()` function
 
@@ -55,8 +55,7 @@ def open(resource, /, use_async: bool = False) -> AerovalDB:
         - 'path', being a json_files dabasase (for example, '.' is equivalent to 'json_files:.')
         - ':memory:' an sqlite in-memory database. Contents are not persistently
         stored!
-    :param use_async : Not used. Should be removed in v0.3.0
-    :return: an implementation-object of AerovalDB openend to a location
+    :return: an implementation-instance of AerovalDB openend to a location
 
     Examples
 

--- a/src/aerovaldb/sqlitedb/sqlitedb.py
+++ b/src/aerovaldb/sqlitedb/sqlitedb.py
@@ -890,7 +890,7 @@ class AerovalSqliteDB(AerovalDB):
         model: str,
         /,
         *args,
-        timestep: str | None = None,
+        timestep: str,
         access_type: str | AccessType = AccessType.OBJ,
         cache: bool = False,
         default=None,
@@ -948,7 +948,7 @@ class AerovalSqliteDB(AerovalDB):
         obsvar: str,
         model: str,
         /,
-        timestep: str | None = None,
+        timestep: str,
         *args,
         **kwargs,
     ):

--- a/src/aerovaldb/sqlitedb/sqlitedb.py
+++ b/src/aerovaldb/sqlitedb/sqlitedb.py
@@ -622,6 +622,7 @@ class AerovalSqliteDB(AerovalDB):
         )
         return lock_file
 
+    @override
     def lock(self):
         if self._use_real_lock:
             return FileLock(self._get_lock_file())

--- a/src/aerovaldb/utils/string_mapper/mapper.py
+++ b/src/aerovaldb/utils/string_mapper/mapper.py
@@ -1,8 +1,14 @@
 import logging
+import sys
 from abc import ABC
 from typing import Awaitable, Callable, Mapping
 
 from packaging.version import Version
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +149,7 @@ class VersionConstraintMapper(Mapper):
 
         self.template = template
 
+    @override
     async def __call__(self, *args, **kwargs) -> str:
         version_provider = kwargs.pop("version_provider")
         version = await version_provider(kwargs["project"], kwargs["experiment"])
@@ -192,6 +199,7 @@ class PriorityMapper(Mapper):
                 self.templates.append(k)
                 self.match.append(v)
 
+    @override
     async def __call__(self, *args, **kwargs) -> str:
         selected_template = None
         for t, m in zip(self.templates, self.match):
@@ -212,5 +220,6 @@ class ConstantMapper(Mapper):
     def __init__(self, template: str):
         self.template = template
 
+    @override
     async def __call__(self, *args, **kwargs) -> str:
         return self.template

--- a/tests/test_aerovaldb.py
+++ b/tests/test_aerovaldb.py
@@ -72,12 +72,6 @@ GET_PARAMETRIZATION = pytest.mark.parametrize(
         (
             "get_contour",
             ["project", "experiment", "modvar", "model"],
-            None,
-            "./project/experiment/contour/",
-        ),
-        (
-            "get_contour",
-            ["project", "experiment", "modvar", "model"],
             {"timestep": "timestep"},
             "748956457892",
         ),
@@ -216,7 +210,6 @@ PUT_PARAMETRIZATION = pytest.mark.parametrize(
     "fun,args,kwargs",
     (
         ("glob_stats", ["project", "experiment", "frequency"], None),
-        ("contour", ["project", "experiment", "obsvar", "model"], None),
         (
             "timeseries",
             ["project", "experiment", "location", "network", "obsvar", "layer"],

--- a/tests/test_aerovaldb.py
+++ b/tests/test_aerovaldb.py
@@ -312,7 +312,7 @@ async def test_getter(testdb: str, fun: str, args: list, kwargs: dict, expected)
     """
     This test tests that data is read as expected from a static, fixed database.
     """
-    with aerovaldb.open(testdb, use_async=True) as db:
+    with aerovaldb.open(testdb) as db:
         f = getattr(db, fun)
 
         if kwargs is not None:
@@ -326,7 +326,7 @@ async def test_getter(testdb: str, fun: str, args: list, kwargs: dict, expected)
 @TESTDB_PARAMETRIZATION
 @GET_PARAMETRIZATION
 def test_getter_sync(testdb: str, fun: str, args: list, kwargs: dict, expected):
-    with aerovaldb.open(testdb, use_async=False) as db:
+    with aerovaldb.open(testdb) as db:
         f = getattr(db, fun)
 
         if kwargs is not None:
@@ -340,7 +340,7 @@ def test_getter_sync(testdb: str, fun: str, args: list, kwargs: dict, expected):
 @TESTDB_PARAMETRIZATION
 @GET_PARAMETRIZATION
 def test_getter_json_str(testdb: str, fun: str, args: list, kwargs: dict, expected):
-    with aerovaldb.open(testdb, use_async=False) as db:
+    with aerovaldb.open(testdb) as db:
         f = getattr(db, fun)
 
         if kwargs is not None:


### PR DESCRIPTION
## Change Summary

- Removes asyncio option in `aerovaldb.open()`
- Makes timestep mandatory in `AerovalDB.get_contour()`
- Does not break tests in pyaerocom. Probably doesn't break tests in aeroval-api.

## Related issue number

- closes #112
- closes #109 
- closes #113 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
