### PR TITLE
Cache QueryEntries

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.0.dev0
+version = 0.4.0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.0
+version = 0.4.1.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/__init__.py
+++ b/src/aerovaldb/__init__.py
@@ -5,4 +5,5 @@ __version__ = metadata.version(__package__)
 from .aerovaldb import AerovalDB
 from .exceptions import *
 from .plugins import list_engines, open
+from .routes import Route
 from .types import *

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -217,21 +217,6 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
-    async def list_glob_stats(
-        self,
-        project: str,
-        experiment: str,
-    ) -> list[QueryEntry]:
-        """Lists the URI for each glob_stats object.
-
-        :param project: str
-        :param experiment: str
-
-        :returns: List of URIs.
-        """
-        raise NotImplementedError
-
-    @async_and_sync
     @get_method(Route.CONTOUR)
     async def get_contour(
         self,

--- a/src/aerovaldb/jsondb/backwards_compatibility.py
+++ b/src/aerovaldb/jsondb/backwards_compatibility.py
@@ -1,7 +1,5 @@
 from packaging.version import Version
 
-# The motivation for doing this is explained here:
-# See this issue:
 from ..routes import Route
 
 

--- a/src/aerovaldb/jsondb/backwards_compatibility.py
+++ b/src/aerovaldb/jsondb/backwards_compatibility.py
@@ -49,7 +49,7 @@ def _post_process_maps_args_kwargs(
 def _post_process_timeseries_args_kwargs(
     args: dict[str, str], kwargs: dict[str, str], *, version
 ) -> tuple[dict[str, str], dict[str, str]]:
-    if version >= Version("0.26.0"):
+    if version >= Version("0.29.0.dev1"):
         return args, kwargs
 
     if "-" in args["obsvar"]:
@@ -82,7 +82,7 @@ def _post_process_scatter_args_kwargs(
 def _post_process_heatmap_ts_args_kwargs(
     args: dict[str, str], kwargs: dict[str, str], *, version
 ) -> tuple[dict[str, str], dict[str, str]]:
-    if version >= Version("0.26.0"):
+    if version >= Version("0.29.0.dev1"):
         return args, kwargs
     if version <= Version("0.12.2"):
         return args, kwargs

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -468,7 +468,7 @@ class AerovalJsonFileDB(AerovalDB):
         )
 
     @async_and_sync
-    @alru_cache
+    @alru_cache(maxsize=1000)
     async def _get_query_entry_for_file(self, file_path: str) -> QueryEntry:
         """
         For the provided data file path, returns the corresponding

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -40,6 +40,8 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
+from async_lru import alru_cache
+
 from ..utils.encode import decode_str, encode_str
 from ..utils.query import QueryEntry
 from .backwards_compatibility import post_process_args
@@ -469,6 +471,7 @@ class AerovalJsonFileDB(AerovalDB):
         )
 
     @async_and_sync
+    @alru_cache
     async def _get_query_entry_for_file(self, file_path: str) -> QueryEntry:
         """
         For the provided data file path, returns the corresponding
@@ -478,9 +481,6 @@ class AerovalJsonFileDB(AerovalDB):
         """
         file_path = os.path.join(self._basedir, file_path)
         file_path = os.path.relpath(file_path, start=self._basedir)
-
-        if file_path in self._uri_cache:
-            return self._uri_cache[file_path]
 
         _, ext = os.path.splitext(file_path)
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -577,18 +577,6 @@ class AerovalJsonFileDB(AerovalDB):
 
     @async_and_sync
     @override
-    async def list_glob_stats(
-        self,
-        project: str,
-        experiment: str,
-    ):
-        logger.warning("list_all is deprecated. Please consider using query() instead.")
-        return await self.query(
-            Route.GLOB_STATS, project=project, experiment=experiment
-        )
-
-    @async_and_sync
-    @override
     async def list_timeseries(
         self,
         project: str,

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -95,21 +95,21 @@ class AerovalJsonFileDB(AerovalDB):
                 Route.TIMESERIES_WEEKLY: [
                     VersionConstraintMapper(
                         "./{project}/{experiment}/ts/diurnal/{location}_{network}_{obsvar}_{layer}.json",
-                        min_version="0.28.0.dev0",
+                        min_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/ts/diurnal/{location}_{network}-{obsvar}_{layer}.json",
-                        max_version="0.28.0.dev0",
+                        max_version="0.29.0.dev1",
                     ),
                 ],
                 Route.TIMESERIES: [
                     VersionConstraintMapper(
                         "./{project}/{experiment}/ts/{location}_{network}_{obsvar}_{layer}.json",
-                        min_version="0.28.0.dev0",
+                        min_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/ts/{location}_{network}-{obsvar}_{layer}.json",
-                        max_version="0.28.0.dev0",
+                        max_version="0.29.0.dev1",
                     ),
                 ],
                 Route.EXPERIMENTS: "./{project}/experiments.json",
@@ -125,12 +125,12 @@ class AerovalJsonFileDB(AerovalDB):
                 Route.MAP: [
                     VersionConstraintMapper(
                         "./{project}/{experiment}/map/{network}_{obsvar}_{layer}_{model}_{modvar}_{time}.json",
-                        min_version="0.28.0.dev0",
+                        min_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/map/{network}-{obsvar}_{layer}_{model}-{modvar}_{time}.json",
                         min_version="0.13.2",
-                        max_version="0.28.0.dev0",
+                        max_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/map/{network}-{obsvar}_{layer}_{model}-{modvar}.json",
@@ -140,12 +140,12 @@ class AerovalJsonFileDB(AerovalDB):
                 Route.SCATTER: [
                     VersionConstraintMapper(
                         "./{project}/{experiment}/scat/{network}_{obsvar}_{layer}_{model}_{modvar}_{time}.json",
-                        min_version="0.28.0.dev0",
+                        min_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/scat/{network}-{obsvar}_{layer}_{model}-{modvar}_{time}.json",
                         min_version="0.13.2",
-                        max_version="0.28.0.dev0",
+                        max_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/scat/{network}-{obsvar}_{layer}_{model}-{modvar}.json",
@@ -156,12 +156,12 @@ class AerovalJsonFileDB(AerovalDB):
                 Route.HEATMAP_TIMESERIES: [
                     VersionConstraintMapper(
                         "./{project}/{experiment}/hm/ts/{region}_{network}_{obsvar}_{layer}.json",
-                        min_version="0.28.0.dev0",
+                        min_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/hm/ts/{region}-{network}-{obsvar}-{layer}.json",
                         min_version="0.13.2",  # https://github.com/metno/pyaerocom/blob/4478b4eafb96f0ca9fd722be378c9711ae10c1f6/setup.cfg
-                        max_version="0.28.0.dev0",
+                        max_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/hm/ts/{network}-{obsvar}-{layer}.json",
@@ -176,11 +176,11 @@ class AerovalJsonFileDB(AerovalDB):
                 Route.FORECAST: [
                     VersionConstraintMapper(
                         "./{project}/{experiment}/forecast/{region}_{network}_{obsvar}_{layer}.json",
-                        min_version="0.28.0.dev0",
+                        min_version="0.29.0.dev1",
                     ),
                     VersionConstraintMapper(
                         "./{project}/{experiment}/forecast/{region}_{network}-{obsvar}_{layer}.json",
-                        max_version="0.28.0.dev0",
+                        max_version="0.29.0.dev1",
                     ),
                 ],
                 Route.GRIDDED_MAP: "./{project}/{experiment}/contour/{obsvar}_{model}.json",

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -12,7 +12,6 @@ from typing import Any, Awaitable, Callable, Iterable
 
 import filetype  # type: ignore
 import simplejson  # type: ignore
-from async_lru import alru_cache
 from packaging.version import Version
 
 from aerovaldb.aerovaldb import AerovalDB
@@ -69,8 +68,6 @@ class AerovalJsonFileDB(AerovalDB):
         """
         :param basedir The root directory where aerovaldb will look for files.
         """
-        self._uri_cache: dict[str, QueryEntry] = {}
-
         self._use_real_lock = str_to_bool(
             os.environ.get("AVDB_USE_LOCKING", ""), default=False
         )
@@ -513,7 +510,6 @@ class AerovalJsonFileDB(AerovalDB):
                 Route.REPORT_IMAGE,
                 {"project": project, "experiment": experiment, "path": path},
             )
-            self._uri_cache[file_path] = entry
             return entry
 
         for route in self.PATH_LOOKUP._lookuptable:
@@ -570,7 +566,6 @@ class AerovalJsonFileDB(AerovalDB):
             else:
                 uri = build_uri(route, route_args, kwargs | {"version": str(version)})
                 entry = QueryEntry(uri, Route(route), route_args | kwargs)
-                self._uri_cache[file_path] = entry
                 return entry
 
         raise ValueError(f"Unable to build URI for file path {file_path}")

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -85,9 +85,9 @@ class AerovalJsonFileDB(AerovalDB):
 
         self.PATH_LOOKUP = StringMapper(
             {
+                Route.HEATMAP: "./{project}/{experiment}/hm/glob_stats_{frequency}.json",
                 Route.GLOB_STATS: "./{project}/{experiment}/hm/glob_stats_{frequency}.json",
                 Route.REGIONAL_STATS: "./{project}/{experiment}/hm/glob_stats_{frequency}.json",
-                Route.HEATMAP: "./{project}/{experiment}/hm/glob_stats_{frequency}.json",
                 # For MAP_OVERLAY, extension is excluded but it will be appended after the fact.
                 Route.MAP_OVERLAY: "./{project}/{experiment}/overlay/{variable}_{source}/{variable}_{source}_{date}",
                 Route.CONTOUR: "./{project}/{experiment}/contour/{obsvar}_{model}.geojson",

--- a/src/aerovaldb/sqlitedb/sqlitedb.py
+++ b/src/aerovaldb/sqlitedb/sqlitedb.py
@@ -638,49 +638,6 @@ class AerovalSqliteDB(AerovalDB):
 
         return FakeLock()
 
-    @override
-    def list_glob_stats(
-        self,
-        project: str,
-        experiment: str,
-        /,
-        access_type: str | AccessType = AccessType.URI,
-    ):
-        if access_type != AccessType.URI:
-            raise ValueError(
-                f"Invalid access_type. Got {access_type}, expected AccessType.URI"
-            )
-
-        cur = self._con.cursor()
-        cur.execute(
-            f"""
-            SELECT * FROM glob_stats
-            WHERE project=? AND experiment=?
-            """,
-            (project, experiment),
-        )
-        fetched = cur.fetchall()
-
-        route = AerovalSqliteDB.TABLE_NAME_TO_ROUTE["glob_stats"]
-        result = []
-        for r in fetched:
-            arg_names = _column_titles_from_route(route)
-            route_args = {}
-            kwargs = {}
-            for k in r.keys():
-                if k in ["json", "blob", "ctime", "mtime"]:
-                    continue
-
-                if k in arg_names:
-                    route_args[k] = r[k]
-                else:
-                    kwargs[k] = r[k]
-
-            uri = build_uri(route, route_args, kwargs)
-            result.append(uri)
-
-        return result
-
     @async_and_sync
     @override
     async def list_timeseries(

--- a/tests/test_aerovaldb.py
+++ b/tests/test_aerovaldb.py
@@ -480,14 +480,6 @@ def test_version2(testdb):
         assert str(db._get_version("project", "experiment-old")) == "0.0.5"
 
 
-@TESTDB_PARAMETRIZATION
-def test_list_glob_stats(testdb):
-    with aerovaldb.open(testdb) as db:
-        glob_stats = db.list_glob_stats("project", "experiment")
-
-        assert len(glob_stats) == 1
-
-
 @pytest.mark.dependency(scope="session", name="test_list_all")
 @TESTDB_PARAMETRIZATION
 def test_list_all(testdb):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aerovaldb.routes import *
+from aerovaldb import Route
 from aerovaldb.utils import (
     decode_arg,
     encode_arg,


### PR DESCRIPTION
## Change Summary

- `QueryEntrys` are cached and are only generated for a file once. Should improve performance of querying significantly.

For the test database with ~50 assets, caching improves querying all assets from 0.026 seconds to 0.003 seconds once the cache has been primed.

- Removed list_glob_stats as its name is misleading. It listed heatmap files. As part of https://github.com/metno/pyaerocom/pull/1529 pyaerocom will use query for this function.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
