### PR TITLE
Fix double encode when reading config to get pyaerocom version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.1
+version = 0.4.2.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.1.dev0
+version = 0.4.1
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.2.dev0
+version = 0.4.1
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -9,6 +9,7 @@ from aerovaldb.utils.query import QueryEntry
 from .routes import Route
 from .types import AccessType
 from .utils import async_and_sync
+from .utils.encode import DecodedStr
 
 
 def get_method(route):
@@ -38,7 +39,11 @@ def get_method(route):
                         )
             if len(args) > 0:
                 raise IndexError(f"{len(args)} superfluous positional args provided.")
-            return await self._get(route, route_args, *args, **kwargs)
+            return await self._get(
+                route,
+                route_args,
+                **kwargs,
+            )
 
         return wrapper
 
@@ -72,7 +77,12 @@ def put_method(route):
                         )
             if len(args) > 0:
                 raise IndexError(f"{len(args)} superfluous positional args provided.")
-            return await self._put(obj, route, route_args, **kwargs)
+            return await self._put(
+                obj,
+                route,
+                route_args,
+                **kwargs,
+            )
 
         return wrapper
 

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -232,6 +232,10 @@ class AerovalJsonFileDB(AerovalDB):
 
         :return : A Version object.
         """
+        project = decode_str(project, encode_chars=AerovalJsonFileDB.FNAME_ENCODE_CHARS)
+        experiment = decode_str(
+            experiment, encode_chars=AerovalJsonFileDB.FNAME_ENCODE_CHARS
+        )
         try:
             config = await self.get_config(project, experiment)
         except FileNotFoundError:

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -305,9 +305,6 @@ class AerovalJsonFileDB(AerovalDB):
         path_template = await self._get_template(route, (route_args | kwargs))
         logger.debug(f"Using template string {path_template}")
 
-        assert all(
-            isinstance(v, DecodedStr | str) for v in (route_args | kwargs).values()
-        )
         substitutions = self._prepare_substitutions(route_args | kwargs)
 
         logger.debug(f"Fetching data for {route}.")

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -227,8 +227,8 @@ class AerovalJsonFileDB(AerovalDB):
         Returns the version of pyaerocom used to generate the files for a given project
         and experiment.
 
-        :param project : Project ID.
-        :param experiment : Experiment ID.
+        :param project : Encoded Project ID.
+        :param experiment : Encoded Experiment ID.
 
         :return : A Version object.
         """

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -234,6 +234,8 @@ class AerovalJsonFileDB(AerovalDB):
 
         :return : A Version object.
         """
+        # assert isinstance(project, DecodedStr)
+        # assert isinstance(experiment, DecodedStr)
         try:
             config = await self.get_config(project, experiment)
         except FileNotFoundError:
@@ -273,6 +275,7 @@ class AerovalJsonFileDB(AerovalDB):
         :raises TemplateNotFound :
             If no valid template was found.
         """
+        # assert all([isinstance(v, DecodedStr) for v in substitutions.values()])
         return await self.PATH_LOOKUP.lookup(route, **substitutions)
 
     @override

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -234,8 +234,6 @@ class AerovalJsonFileDB(AerovalDB):
 
         :return : A Version object.
         """
-        # assert isinstance(project, DecodedStr)
-        # assert isinstance(experiment, DecodedStr)
         try:
             config = await self.get_config(project, experiment)
         except FileNotFoundError:
@@ -275,7 +273,6 @@ class AerovalJsonFileDB(AerovalDB):
         :raises TemplateNotFound :
             If no valid template was found.
         """
-        # assert all([isinstance(v, DecodedStr) for v in substitutions.values()])
         return await self.PATH_LOOKUP.lookup(route, **substitutions)
 
     def _prepare_substitutions(self, subs: dict[str, _LiteralArg | DecodedStr]) -> dict:

--- a/src/aerovaldb/utils/encode.py
+++ b/src/aerovaldb/utils/encode.py
@@ -1,4 +1,12 @@
-def encode_str(string: str, *, encode_chars: dict[str, str]) -> str:
+class EncodedStr(str):
+    pass
+
+
+class DecodedStr(str):
+    pass
+
+
+def encode_str(string: str, *, encode_chars: dict[str, str]) -> EncodedStr:
     """Encodes a string by replacing characters by en encoded
     character sequence.
 
@@ -8,11 +16,14 @@ def encode_str(string: str, *, encode_chars: dict[str, str]) -> str:
 
     :return: Encoded string.
     """
+    if isinstance(string, EncodedStr):
+        raise TypeError(f"String '{string}' is already encoded.")
+
     mapping = str.maketrans(encode_chars)
-    return string.translate(mapping)
+    return EncodedStr(string.translate(mapping))
 
 
-def decode_str(string: str, *, encode_chars: dict[str, str]) -> str:
+def decode_str(string: str, *, encode_chars: dict[str, str]) -> DecodedStr:
     """Decodes a string previously encoded using encode_str.
 
     :param string: String to be decoded.
@@ -20,6 +31,9 @@ def decode_str(string: str, *, encode_chars: dict[str, str]) -> str:
     used during the original encode operation.
     :return: Decoded string.
     """
+    if isinstance(string, DecodedStr):
+        raise TypeError(f"String '{string}' is already decoded.")
+
     for k, v in encode_chars.items():
         string = string.replace(v, k)
-    return string
+    return DecodedStr(string)


### PR DESCRIPTION
## Change Summary

Aerovaldb relies on the cfg_.json file to find the pyaerocom version that wrote a file. When fetching this file to find the version arguments where encoded twice, resulting in attempts to access the wrong file.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
