### PR TITLE
Reintroduce `list_glob_stats` and ensure backwards compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.3
+version = 0.4.4.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.3.dev0
+version = 0.4.3
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -347,6 +347,23 @@ class AerovalDB(abc.ABC):
         raise NotImplementedError
 
     @async_and_sync
+    async def list_glob_stats(
+        self,
+        project: str,
+        experiment: str,
+        /,
+        access_type: str | AccessType = AccessType.URI,
+    ) -> list[str]:
+        """Lists the URI for each glob_stats object.
+
+        :param project: str
+        :param experiment: str
+
+        :returns: List of URIs.
+        """
+        raise NotImplementedError
+
+    @async_and_sync
     async def list_timeseries(
         self,
         project: str,
@@ -1019,7 +1036,7 @@ class AerovalDB(abc.ABC):
         :returns: The fetched data.
         """
         raise NotImplementedError
-    
+
     @async_and_sync
     @get_method(Route.FAIRMODE)
     async def get_fairmode(
@@ -1081,7 +1098,7 @@ class AerovalDB(abc.ABC):
         :param layer: Layer.
         """
         raise NotImplementedError
-    
+
     @async_and_sync
     @put_method(Route.FAIRMODE)
     async def put_fairmode(

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -596,9 +596,12 @@ class AerovalJsonFileDB(AerovalDB):
         experiment: str,
     ):
         logger.warning("list_all is deprecated. Please consider using query() instead.")
-        return await self.query(
-            Route.TIMESERIES, project=project, experiment=experiment
-        )
+        return [
+            uri.uri
+            for uri in await self.query(
+                Route.TIMESERIES, project=project, experiment=experiment
+            )
+        ]
 
     @async_and_sync
     @override
@@ -608,7 +611,12 @@ class AerovalJsonFileDB(AerovalDB):
         experiment: str,
     ):
         logger.warning("list_all is deprecated. Please consider using query() instead.")
-        return await self.query(Route.MAP, project=project, experiment=experiment)
+        return [
+            uri.uri
+            for uri in await self.query(
+                Route.MAP, project=project, experiment=experiment
+            )
+        ]
 
     @async_and_sync
     @override
@@ -728,7 +736,7 @@ class AerovalJsonFileDB(AerovalDB):
     @override
     async def list_all(self):
         logger.warning("list_all is deprecated. Please consider using query() instead.")
-        return await self.query()
+        return [uri.uri for uri in await self.query()]
 
     @async_and_sync
     @override
@@ -1031,3 +1039,24 @@ class AerovalJsonFileDB(AerovalDB):
 
         if os.path.exists(file_path):
             os.remove(file_path)
+
+    @async_and_sync
+    @override
+    async def list_glob_stats(
+        self,
+        project: str,
+        experiment: str,
+        /,
+        access_type: str | AccessType = AccessType.URI,
+    ) -> list[str]:
+        logger.warning("list_glob_stats() is deprecated. Please use query instead.")
+
+        # Route.HEATMAP below is intentional, as this maintains old behaviour for compatibility.
+        # Will be removed in future since the name is misleading (it returns heatmap while being
+        # named list_glob_stats).
+        return [
+            uri.uri
+            for uri in await self.query(
+                Route.HEATMAP, project=project, experiment=experiment
+            )
+        ]

--- a/src/aerovaldb/sqlitedb/sqlitedb.py
+++ b/src/aerovaldb/sqlitedb/sqlitedb.py
@@ -951,3 +951,47 @@ class AerovalSqliteDB(AerovalDB):
                 "timestep": timestep,
             },
         )
+
+    @async_and_sync
+    @override
+    async def list_glob_stats(
+        self,
+        project: str,
+        experiment: str,
+        /,
+        access_type: str | AccessType = AccessType.URI,
+    ):
+        if access_type != AccessType.URI:
+            raise ValueError(
+                f"Invalid access_type. Got {access_type}, expected AccessType.URI"
+            )
+
+        cur = self._con.cursor()
+        cur.execute(
+            f"""
+            SELECT * FROM glob_stats
+            WHERE project=? AND experiment=?
+            """,
+            (project, experiment),
+        )
+        fetched = cur.fetchall()
+
+        route = AerovalSqliteDB.TABLE_NAME_TO_ROUTE["glob_stats"]
+        result = []
+        for r in fetched:
+            arg_names = extract_substitutions(route.value)
+            route_args = {}
+            kwargs = {}
+            for k in r.keys():
+                if k in ["json", "blob", "ctime", "mtime"]:
+                    continue
+
+                if k in arg_names:
+                    route_args[k] = r[k]
+                else:
+                    kwargs[k] = r[k]
+
+            uri = build_uri(route, route_args, kwargs)
+            result.append(uri)
+
+        return result

--- a/tests/test_aerovaldb.py
+++ b/tests/test_aerovaldb.py
@@ -669,3 +669,11 @@ def test_get_map_filtering(testdb):
     assert not "excluded_frequency" in data[0]
     assert "season" in data[0]["frequency"]
     assert not "excluded_season" in data[0]["frequency"]
+
+
+@TESTDB_PARAMETRIZATION
+def test_list_glob_stats(testdb):
+    with aerovaldb.open(testdb) as db:
+        glob_stats = db.list_glob_stats("project", "experiment")
+
+        assert len(glob_stats) == 1


### PR DESCRIPTION
## Change Summary

- Reintroduces `list_glob_stats`.
- Make `list_*` functions return string uri again, instead of `QueryEntry` instances

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
