### PR TITLE
try fix reports issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.4.dev0
+version = 0.4.4
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.4
+version = 0.4.5.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -1060,3 +1060,29 @@ class AerovalJsonFileDB(AerovalDB):
                 Route.HEATMAP, project=project, experiment=experiment
             )
         ]
+
+    @async_and_sync
+    @override
+    async def get_report(
+        self,
+        project: str,
+        experiment: str,
+        title: str,
+        /,
+        *args,
+        access_type: str | AccessType = AccessType.OBJ,
+        cache: bool = False,
+        default=None,
+        **kwargs,
+    ):
+        return await self._get(
+            Route.REPORT,
+            {
+                "project": project,
+                "experiment": experiment,
+                "title": _LiteralArg(title),
+            },
+            access_type=access_type,
+            cache=cache,
+            default=default,
+        )

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -1078,11 +1078,34 @@ class AerovalJsonFileDB(AerovalDB):
         return await self._get(
             Route.REPORT,
             {
-                "project": project,
-                "experiment": experiment,
+                "project": _LiteralArg(project),
+                "experiment": _LiteralArg(experiment),
                 "title": _LiteralArg(title),
             },
             access_type=access_type,
             cache=cache,
             default=default,
+        )
+
+    @async_and_sync
+    @override
+    async def put_report(
+        self, obj, project: str, experiment: str, title: str, /, *args, **kwargs
+    ):
+        """Store report.
+
+        :param obj: The object to be stored.
+        :param project: Project ID.
+        :param experiment: Experiment ID.
+        :param title: Report title (ie. filename without extension).
+        """
+        await self._put(
+            obj,
+            Route.REPORT,
+            {
+                "project": _LiteralArg(project),
+                "experiment": _LiteralArg(experiment),
+                "title": _LiteralArg(title),
+            },
+            **kwargs,
         )


### PR DESCRIPTION
## Change Summary

Fix report issue with `get_report()`.

The introduction of encoding in filenames broke `get_report` as it would try to fetch paths with underscores encoded. This PR, changes `title` to a literal arg as is used for paths, to prevent encoding from being applied. It may be necessary to treat project and experiment as `_LiteralArgs` as well for this endpoint unless we rename the files.

## Related issue number

Chat

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
