### PR TITLE
Fix encoding for old exp

### DIFF
--- a/src/aerovaldb/aerovaldb.py
+++ b/src/aerovaldb/aerovaldb.py
@@ -498,7 +498,7 @@ class AerovalDB(abc.ABC):
         cache: bool = False,
         default=None,
         **kwargs,
-    ) -> int:
+    ):
         """Fetches a configuration from the db.
 
         :param project: Project ID.

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -1109,3 +1109,56 @@ class AerovalJsonFileDB(AerovalDB):
             },
             **kwargs,
         )
+
+    @async_and_sync
+    @override
+    async def get_config(
+        self,
+        project: str,
+        experiment: str,
+        /,
+        *args,
+        access_type: str | AccessType = AccessType.OBJ,
+        cache: bool = False,
+        default=None,
+        **kwargs,
+    ):
+        data = None
+        try:
+            data = await self._get(
+                Route.CONFIG,
+                {
+                    "project": _LiteralArg(project),
+                    "experiment": _LiteralArg(experiment),
+                },
+                access_type=access_type,
+                cache=cache,
+            )
+        except FileNotFoundError:
+            data = await self._get(
+                Route.CONFIG,
+                {"project": project, "experiment": experiment},
+                access_type=access_type,
+                cache=cache,
+            )
+
+        if data is None and default is not None:
+            data = default
+
+        if data is not None:
+            return data
+
+        raise FileNotFoundError
+
+    @async_and_sync
+    @override
+    async def put_config(self, obj, project: str, experiment: str, /, *args, **kwargs):
+        await self._put(
+            obj,
+            Route.CONFIG,
+            {
+                "project": _LiteralArg(project),
+                "experiment": _LiteralArg(experiment),
+            },
+            **kwargs,
+        )

--- a/src/aerovaldb/jsondb/jsonfiledb.py
+++ b/src/aerovaldb/jsondb/jsonfiledb.py
@@ -313,6 +313,12 @@ class AerovalJsonFileDB(AerovalDB):
         relative_path = path_template.format(**substitutions)
 
         file_path = os.path.join(self._basedir, relative_path)
+
+        if not os.path.exists(file_path):
+            file_path = os.path.join(
+                self._basedir, path_template.format(**(route_args | kwargs))
+            )
+
         logger.debug(f"Fetching file {file_path} as {access_type}-")
 
         filter_func = self.FILTERS.get(route, None)


### PR DESCRIPTION
## Change Summary

Fixes issue with encoding being applied to old files, thus being unable to read them. The fix involves trying to read the encoded, and the decoded file path if the former breaks, which isn't pretty, but it works.

The reason for this is that aerovaldb relies on the config file to know which version of pyaerocom wrote the experiment, which is needed to know whether to apply the encoding. Since the cfg file is also potentially encoded, it is at some point necessary to try both to break the cycle.

It may be a good idea to write the version to a different file that is not affected by this, eg a .version file (or this could be a small part of introducing a file index).

## Related issue number

closes #128 

## Checklist

* [x] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
