### PR TITLE
Fix missing key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.8
+version = 0.4.9.dev0
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aerovaldb
-version = 0.4.8.dev0
+version = 0.4.8
 author = Augustin Mortier, Thorbjørn Lundin, Heiko Klein
 author_email = Heiko.Klein@met.no
 description = aeroval database to communicate between pyaerocom and aeroval

--- a/src/aerovaldb/utils/filter.py
+++ b/src/aerovaldb/utils/filter.py
@@ -64,6 +64,7 @@ def filter_map(data, frequency: str | None = None, season: str | None = None):
             "longitude",
             "altitude",
             "region",
+            "station_display_name",
             frequency,
         }
         for item in data:


### PR DESCRIPTION
## Change Summary

Map filtering uses a whitelist of keys to include, which excludes the station_display_name introduced by [this pr](https://github.com/metno/pyaerocom/pull/1634). This includes that key in the whitelist.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
